### PR TITLE
Preserve space on linguistic feature notes

### DIFF
--- a/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
@@ -46,7 +46,7 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
+               <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -89,7 +89,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s good.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -147,7 +147,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -185,7 +185,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li</hi>
                      + <hi rend="italic">’ayy</hi> or <hi rend="italic">li</hi> + <hi rend="italic">’ayy</hi> +
                      <hi rend="itelic">šay’</hi>
@@ -221,7 +221,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī</hi> + <hi rend="italic">’ayna</hi>
                </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -252,7 +252,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -296,7 +296,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from Cairo.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -344,7 +344,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -388,7 +388,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -429,7 +429,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -460,7 +460,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters and three sons.</quote>
                <cit type="translation">
@@ -500,7 +500,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in K. A.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -542,7 +542,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -578,7 +578,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -600,7 +600,7 @@
          <div type="featureGroup">
             <head>Presentatives</head>
             <cit type="featureSample">
-               <lbl>there is … (m.)</lbl>
+               <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -634,7 +634,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (f.)</lbl>
+               <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -669,7 +669,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="semlib:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -696,7 +696,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -734,7 +734,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -762,7 +762,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -782,7 +782,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -809,7 +809,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -843,7 +843,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="semlib:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -870,7 +870,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -904,7 +904,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -931,7 +931,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -961,7 +961,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="semlib:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1006,7 +1006,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="semlib:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1062,7 +1062,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1108,7 +1108,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1144,7 +1144,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1167,7 +1167,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1192,7 +1192,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -1224,7 +1224,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="semlib:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1261,7 +1261,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1297,7 +1297,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1324,7 +1324,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1343,7 +1343,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1365,7 +1365,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1387,7 +1387,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1424,7 +1424,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to him.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1477,7 +1477,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1509,7 +1509,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea please.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1547,7 +1547,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with you. („here you are?“)</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1584,7 +1584,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1620,7 +1620,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>
@@ -1656,7 +1656,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="semlib:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking bread.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1694,7 +1694,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1730,7 +1730,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1767,7 +1767,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1800,7 +1800,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="semlib:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1831,7 +1831,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play chess? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1861,7 +1861,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1880,7 +1880,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="semlib:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1907,7 +1907,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1935,7 +1935,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
@@ -47,7 +47,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -186,7 +186,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">li</hi>
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li</hi>
                      + <hi rend="italic">’ayy</hi> or <hi rend="italic">li</hi> + <hi rend="italic">’ayy</hi> +
                      <hi rend="itelic">šay’</hi>
                </note>
@@ -222,7 +222,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">fī</hi> + <hi rend="italic">’ayna</hi>
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī</hi> + <hi rend="italic">’ayna</hi>
                </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1621,7 +1621,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects
+               <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -47,7 +47,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -165,7 +165,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">li
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
@@ -200,7 +200,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">fī
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -1602,7 +1602,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects
+               <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -46,7 +46,7 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
+               <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -81,7 +81,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
@@ -125,7 +125,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -164,7 +164,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
@@ -199,7 +199,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
@@ -233,7 +233,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -275,7 +275,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Cairo.</quote>
                <cit type="translation">
@@ -321,7 +321,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -360,7 +360,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -401,7 +401,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -437,7 +437,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
@@ -482,7 +482,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -526,7 +526,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -562,7 +562,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -580,7 +580,7 @@
          <div type="featureGroup">
             <head>Presentatives</head>
             <cit type="featureSample">
-               <lbl>there is … (m.)</lbl>
+               <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -611,7 +611,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (f.)</lbl>
+               <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -635,7 +635,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="vtLex:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -660,7 +660,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -699,7 +699,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -728,7 +728,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -756,7 +756,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -782,7 +782,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -826,7 +826,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="vtLex:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -851,7 +851,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -887,7 +887,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -916,7 +916,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -946,7 +946,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="vtLex:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -988,7 +988,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="vtLex:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1025,7 +1025,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1065,7 +1065,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1096,7 +1096,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1123,7 +1123,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1146,7 +1146,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -1178,7 +1178,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="vtLex:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1219,7 +1219,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1269,7 +1269,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1297,7 +1297,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1326,7 +1326,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1348,7 +1348,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1369,7 +1369,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1402,7 +1402,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
@@ -1447,7 +1447,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1477,7 +1477,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
                <cit type="translation">
@@ -1520,7 +1520,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
                <cit type="translation">
@@ -1565,7 +1565,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1601,7 +1601,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
@@ -1632,7 +1632,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="vtLex:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
                <cit type="translation">
@@ -1680,7 +1680,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1718,7 +1718,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1755,7 +1755,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1789,7 +1789,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="vtLex:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1820,7 +1820,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play domino? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1849,7 +1849,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="vtLex:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1868,7 +1868,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="vtLex:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1896,7 +1896,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1923,7 +1923,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
@@ -47,7 +47,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -131,7 +131,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">li
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
@@ -159,7 +159,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">fī
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -1146,7 +1146,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects 
+               <note xml:space="preserve">Many Arabic dialects 
                      use periphrastic constructions to render 
                      English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
@@ -46,7 +46,7 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
+               <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -74,7 +74,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
@@ -104,7 +104,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -130,7 +130,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
@@ -158,7 +158,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
@@ -181,7 +181,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -208,7 +208,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Cairo.</quote>
                <cit type="translation">
@@ -234,7 +234,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -258,7 +258,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -300,7 +300,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -326,7 +326,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
@@ -352,7 +352,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -379,7 +379,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -407,7 +407,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -421,7 +421,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="bold">Presentatives</hi>
                </lbl>
                <quote xml:lang="en"/>
@@ -438,7 +438,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (m.)</lbl>
+               <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -466,7 +466,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (f.)</lbl>
+               <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -493,7 +493,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="semlib:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -511,7 +511,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -537,7 +537,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -555,7 +555,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -573,7 +573,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -592,7 +592,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -620,7 +620,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="semlib:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -638,7 +638,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -660,7 +660,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -673,7 +673,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -694,7 +694,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="semlib:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -737,7 +737,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="semlib:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -758,7 +758,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -789,7 +789,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -818,7 +818,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall/a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -839,7 +839,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt/car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -862,7 +862,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -885,7 +885,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="semlib:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -911,7 +911,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -935,7 +935,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -952,7 +952,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -970,7 +970,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -986,7 +986,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1002,7 +1002,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1021,7 +1021,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
@@ -1050,7 +1050,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1080,7 +1080,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
                <cit type="translation">
@@ -1107,7 +1107,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
                      you.</quote>
                <cit type="translation">
@@ -1125,7 +1125,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1145,7 +1145,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects 
                      use periphrastic constructions to render 
                      English ‛since’.</note>
@@ -1172,7 +1172,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="semlib:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking 
                      bread.</quote>
                <cit type="translation">
@@ -1194,7 +1194,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1216,7 +1216,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1245,7 +1245,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1268,7 +1268,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="semlib:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1285,7 +1285,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play chess? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1301,7 +1301,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1319,7 +1319,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="semlib:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1337,7 +1337,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1355,7 +1355,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
@@ -46,7 +46,7 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
+               <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -72,7 +72,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
@@ -99,7 +99,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -128,7 +128,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">Often reflexes reflexes of CA <hi rend="italic">li + ’ayy
                      </hi>or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
@@ -149,7 +149,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">Often reflexes of CA <hi rend="italic">fī + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -174,7 +174,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -197,7 +197,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Aleppo.</quote>
                <cit type="translation">
@@ -226,7 +226,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -248,7 +248,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -272,7 +272,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Lira. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -296,7 +296,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
@@ -321,7 +321,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Abu
                      Rammana. </quote>
                <cit type="translation">
@@ -350,7 +350,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -377,7 +377,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -393,7 +393,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="bold">Presentatives</hi>
                </lbl>
                <quote xml:lang="en"/>
@@ -411,7 +411,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>here is … (m.)</lbl>
+               <lbl xml:space="preserve">here is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -445,7 +445,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>here is … (f.)</lbl>
+               <lbl xml:space="preserve">here is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -473,7 +473,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="semlib:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -491,7 +491,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -520,7 +520,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -541,7 +541,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -565,7 +565,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -583,7 +583,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -603,7 +603,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="semlib:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -621,7 +621,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -643,7 +643,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -661,7 +661,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -683,7 +683,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="semlib:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -709,7 +709,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="semlib:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -730,7 +730,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. /car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -772,7 +772,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -798,7 +798,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall/a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -821,7 +821,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt/car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -840,7 +840,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -864,7 +864,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="semlib:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -893,7 +893,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -915,7 +915,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -933,7 +933,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -960,7 +960,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -976,7 +976,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -992,7 +992,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1012,7 +1012,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
@@ -1039,7 +1039,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1059,7 +1059,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea 
                      please.</quote>
                <cit type="translation">
@@ -1087,7 +1087,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
                      you.</quote>
                <cit type="translation">
@@ -1120,7 +1120,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1147,7 +1147,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
@@ -1174,7 +1174,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="semlib:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? –
                      They are baking bread.</quote>
                <cit type="translation">
@@ -1200,7 +1200,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1222,7 +1222,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1251,7 +1251,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1277,7 +1277,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="semlib:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1298,7 +1298,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play barsīs? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1322,7 +1322,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1341,7 +1341,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="semlib:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1359,7 +1359,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1378,7 +1378,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
@@ -47,7 +47,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -129,7 +129,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>Often reflexes reflexes of CA <hi rend="italic">li + ’ayy
+               <note xml:space="preserve">Often reflexes reflexes of CA <hi rend="italic">li + ’ayy
                      </hi>or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
@@ -150,7 +150,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>Often reflexes of CA <hi rend="italic">fī + ’ayna</hi>
+               <note xml:space="preserve">Often reflexes of CA <hi rend="italic">fī + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1148,7 +1148,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects
+               <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
@@ -48,7 +48,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -166,7 +166,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">li
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
@@ -206,7 +206,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">fī
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -1617,7 +1617,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects
+               <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
@@ -47,7 +47,7 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
+               <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -82,7 +82,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
@@ -127,7 +127,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -165,7 +165,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
@@ -205,7 +205,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
@@ -240,7 +240,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -288,7 +288,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      ….</quote>
                <cit type="translation">
@@ -334,7 +334,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -375,7 +375,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -417,7 +417,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -458,7 +458,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
@@ -508,7 +508,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in ... </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -552,7 +552,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -587,7 +587,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -605,7 +605,7 @@
          <div type="featureGroup">
             <head>Presentatives</head>
             <cit type="featureSample">
-               <lbl>there is … (m.)</lbl>
+               <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -637,7 +637,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (f.)</lbl>
+               <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -661,7 +661,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="semlib:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -685,7 +685,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -723,7 +723,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -755,7 +755,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -777,7 +777,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -803,7 +803,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -840,7 +840,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="semlib:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -864,7 +864,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -897,7 +897,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -929,7 +929,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -960,7 +960,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="semlib:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1008,7 +1008,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="semlib:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1045,7 +1045,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1093,7 +1093,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1126,7 +1126,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1155,7 +1155,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1180,7 +1180,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -1213,7 +1213,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="semlib:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1251,7 +1251,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1287,7 +1287,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1319,7 +1319,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1344,7 +1344,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1366,7 +1366,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1387,7 +1387,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1413,7 +1413,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
@@ -1457,7 +1457,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1490,7 +1490,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
                <cit type="translation">
@@ -1529,7 +1529,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
                <cit type="translation">
@@ -1581,7 +1581,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1616,7 +1616,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
@@ -1647,7 +1647,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="semlib:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
                <cit type="translation">
@@ -1687,7 +1687,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1711,7 +1711,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1747,7 +1747,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1784,7 +1784,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="semlib:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1815,7 +1815,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play chess/domino? –
                      Yes.</quote>
                <cit type="translation">
@@ -1859,7 +1859,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1878,7 +1878,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="semlib:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1910,7 +1910,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1938,7 +1938,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -48,7 +48,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -182,7 +182,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">li
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
@@ -223,7 +223,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">fī
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -1671,7 +1671,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects
+               <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -47,8 +47,8 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
-               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <lbl xml:space="preserve">who?</lbl>
+               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -82,7 +82,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
@@ -138,7 +138,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -181,7 +181,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
@@ -222,7 +222,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
@@ -263,7 +263,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -303,7 +303,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      ….</quote>
                <cit type="translation">
@@ -343,7 +343,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -384,7 +384,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -427,7 +427,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -462,7 +462,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
@@ -506,7 +506,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -549,7 +549,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -586,7 +586,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -604,7 +604,7 @@
          <div type="featureGroup">
             <head>Presentatives</head>
             <cit type="featureSample">
-               <lbl>there is … (m.)</lbl>
+               <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -644,7 +644,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (f.)</lbl>
+               <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -668,7 +668,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="semlib:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -702,7 +702,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -749,7 +749,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -778,7 +778,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -809,7 +809,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -835,7 +835,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -875,7 +875,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="semlib:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -903,7 +903,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -936,7 +936,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -968,7 +968,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1004,7 +1004,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="semlib:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1045,7 +1045,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="semlib:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1088,7 +1088,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1131,7 +1131,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1179,7 +1179,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall/a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1207,7 +1207,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1235,7 +1235,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -1273,7 +1273,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="semlib:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1316,7 +1316,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1352,7 +1352,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1384,7 +1384,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1409,7 +1409,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1431,7 +1431,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1452,7 +1452,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1480,7 +1480,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
@@ -1527,7 +1527,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1557,7 +1557,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
                <cit type="translation">
@@ -1595,7 +1595,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
                      you.</quote>
                <cit type="translation">
@@ -1631,7 +1631,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1670,7 +1670,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
@@ -1704,7 +1704,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="semlib:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
                <cit type="translation">
@@ -1744,7 +1744,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1767,7 +1767,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1805,7 +1805,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1846,7 +1846,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="semlib:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1877,7 +1877,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play Shqubba? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1906,7 +1906,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1925,7 +1925,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="semlib:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1957,7 +1957,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1990,7 +1990,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
@@ -47,7 +47,7 @@
          <div type="featureGroup">
             <head>Interrogatives</head>
             <cit type="featureSample">
-               <lbl>who?</lbl>
+               <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -82,7 +82,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>whose?</lbl>
+               <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
@@ -138,7 +138,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>what?</lbl>
+               <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -179,7 +179,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>why?</lbl>
+               <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy </hi>or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
@@ -215,7 +215,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where?</lbl>
+               <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
@@ -246,7 +246,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where to?</lbl>
+               <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -283,7 +283,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>where from?</lbl>
+               <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Harran.</quote>
                <cit type="translation">
@@ -320,7 +320,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>when?</lbl>
+               <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -358,7 +358,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how?</lbl>
+               <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -395,7 +395,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how much?</lbl>
+               <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Lira. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -429,7 +429,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>how many?</lbl>
+               <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
@@ -469,7 +469,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>which?</lbl>
+               <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -508,7 +508,7 @@
          <div type="featureGroup">
             <head>Demonstratives</head>
             <cit type="featureSample">
-               <lbl>this</lbl>
+               <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -544,7 +544,7 @@
          <div type="featureGroup">
             <head>Pronouns</head>
             <cit type="featureSample">
-               <lbl>I</lbl>
+               <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -562,7 +562,7 @@
          <div type="featureGroup">
             <head>Presentatives</head>
             <cit type="featureSample">
-               <lbl>there is … (m.)</lbl>
+               <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -590,7 +590,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>there is … (f.)</lbl>
+               <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -614,7 +614,7 @@
          <div type="featureGroup">
             <head>Adverbs</head>
             <cit type="featureSample" ana="semlib:here">
-               <lbl>here</lbl>
+               <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -641,7 +641,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:now">
-               <lbl>now</lbl>
+               <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -682,7 +682,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:today">
-               <lbl>today</lbl>
+               <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -711,7 +711,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:yesterday">
-               <lbl>yesterday</lbl>
+               <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -733,7 +733,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:tomorrow">
-               <lbl>tomorrow</lbl>
+               <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -760,7 +760,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:last_year">
-               <lbl>last year</lbl>
+               <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -788,7 +788,7 @@
          <div type="featureGroup">
             <head>Numerals</head>
             <cit type="featureSample" ana="semlib:eight">
-               <lbl>eight</lbl>
+               <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -815,7 +815,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eleven">
-               <lbl>eleven</lbl>
+               <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -849,7 +849,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:twelve">
-               <lbl>twelve</lbl>
+               <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -876,7 +876,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:eighteen">
-               <lbl>eighteen</lbl>
+               <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -907,7 +907,7 @@
          <div type="featureGroup">
             <head>Adjectives</head>
             <cit type="featureSample" ana="semlib:good">
-               <lbl>good</lbl>
+               <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -945,7 +945,7 @@
          <div type="featureGroup">
             <head>Colours</head>
             <cit type="featureSample" ana="semlib:white">
-               <lbl>white</lbl>
+               <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -985,7 +985,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:black">
-               <lbl>black</lbl>
+               <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1018,7 +1018,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:pink">
-               <lbl>pink</lbl>
+               <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1041,7 +1041,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:grey">
-               <lbl>grey</lbl>
+               <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1064,7 +1064,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:orange">
-               <lbl>orange</lbl>
+               <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1083,7 +1083,7 @@
          <div type="featureGroup">
             <head>Prepositions</head>
             <cit type="featureSample">
-               <lbl>
+               <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
@@ -1116,7 +1116,7 @@
          <div type="featureGroup">
             <head>Important verbs</head>
             <cit type="featureSample" ana="semlib:to_do">
-               <lbl>to do</lbl>
+               <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1157,7 +1157,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_stay">
-               <lbl>to stay</lbl>
+               <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1190,7 +1190,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_speak">
-               <lbl>to speak</lbl>
+               <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1221,7 +1221,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_rain">
-               <lbl>to rain</lbl>
+               <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1246,7 +1246,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_open">
-               <lbl>to open</lbl>
+               <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1268,7 +1268,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_close">
-               <lbl>to close</lbl>
+               <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1289,7 +1289,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_take">
-               <lbl>to take</lbl>
+               <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1317,7 +1317,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_give">
-               <lbl>to give</lbl>
+               <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
@@ -1360,7 +1360,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_see">
-               <lbl>to see</lbl>
+               <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1390,7 +1390,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_want">
-               <lbl>to want</lbl>
+               <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
                <cit type="translation">
@@ -1428,7 +1428,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_bring">
-               <lbl>to bring</lbl>
+               <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
                <cit type="translation">
@@ -1466,7 +1466,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:to_have">
-               <lbl>to have</lbl>
+               <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1504,7 +1504,7 @@
          <div type="featureGroup">
             <head>Phrasemes</head>
             <cit type="featureSample">
-               <lbl>since/for</lbl>
+               <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
@@ -1540,7 +1540,7 @@
          <div type="featureGroup">
             <head>Nouns</head>
             <cit type="featureSample" ana="semlib:women">
-               <lbl>women</lbl>
+               <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
                <cit type="translation">
@@ -1576,7 +1576,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:husband">
-               <lbl>husband</lbl>
+               <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
@@ -1603,7 +1603,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:friend">
-               <lbl>friend</lbl>
+               <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1640,7 +1640,7 @@
          <div type="featureGroup">
             <head>Neologisms</head>
             <cit type="featureSample">
-               <lbl>mobile vs. cellphone</lbl>
+               <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1672,7 +1672,7 @@
          <div type="featureGroup">
             <head>Modality</head>
             <cit type="featureSample" ana="semlib:being_unable">
-               <lbl>being unable</lbl>
+               <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">     
@@ -1702,7 +1702,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:ability">
-               <lbl>ability</lbl>
+               <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play OK / Mangala? –
                      Yes.</quote>
                <cit type="translation">
@@ -1732,7 +1732,7 @@
                </cit>
             </cit>
             <cit type="featureSample" ana="semlib:possibility">
-               <lbl>possibility</lbl>
+               <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -1751,7 +1751,7 @@
          <div type="featureGroup">
             <head>Other items</head>
             <cit type="featureSample" ana="semlib:a_little">
-               <lbl>a little</lbl>
+               <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1782,7 +1782,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>existential (there is, there are)</lbl>
+               <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -1810,7 +1810,7 @@
                </cit>
             </cit>
             <cit type="featureSample">
-               <lbl>Genitive explicative</lbl>
+               <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">

--- a/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
@@ -48,7 +48,7 @@
             <head>Interrogatives</head>
             <cit type="featureSample">
                <lbl>who?</lbl>
-               <note>Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
+               <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -180,7 +180,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>why?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">li
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy </hi>or <hi rend="italic">li + ’ayy + šay’</hi>
                   </note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
@@ -216,7 +216,7 @@
             </cit>
             <cit type="featureSample">
                <lbl>where?</lbl>
-               <note>A very common pattern are reflexes of CA <hi rend="italic">fī
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
                   </note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
@@ -1505,7 +1505,7 @@
             <head>Phrasemes</head>
             <cit type="featureSample">
                <lbl>since/for</lbl>
-               <note>Many Arabic dialects
+               <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
                      English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>


### PR DESCRIPTION
The whitespaces might be chopped upon importing to baseX depending on environemtnt settings, so we should preserve spaces explicitly in <note> and <lbl> tags which can have chilc elements where space is relevant.