### PR TITLE
Add most missing @ana tags on words and add them on wrappers to enable highlighting

### DIFF
--- a/vicav.xpr
+++ b/vicav.xpr
@@ -10761,21 +10761,6 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                 </field>
                                 <field name="scenarioIds">
                                     <list>
-                                        <String>lingfeatures v1 to v2</String>
-                                    </list>
-                                </field>
-                                <field name="scenarioTypes">
-                                    <list>
-                                        <String>XSL</String>
-                                    </list>
-                                </field>
-                            </scenarioAssociation>
-                            <scenarioAssociation>
-                                <field name="url">
-                                    <String>vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml</String>
-                                </field>
-                                <field name="scenarioIds">
-                                    <list>
                                         <String>vicav_lingfeatures_add_ana</String>
                                     </list>
                                 </field>
@@ -10792,6 +10777,21 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                 <field name="scenarioIds">
                                     <list>
                                         <String>lingfeatures v1 to v2</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioTypes">
+                                    <list>
+                                        <String>XSL</String>
+                                    </list>
+                                </field>
+                            </scenarioAssociation>
+                            <scenarioAssociation>
+                                <field name="url">
+                                    <String>vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml</String>
+                                </field>
+                                <field name="scenarioIds">
+                                    <list>
+                                        <String>vicav_lingfeatures_add_ana</String>
                                     </list>
                                 </field>
                                 <field name="scenarioTypes">
@@ -12022,13 +12022,13 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                     <String>XSL</String>
                                 </field>
                                 <field name="saveAs">
-                                    <Boolean>false</Boolean>
+                                    <Boolean>true</Boolean>
                                 </field>
                                 <field name="openInBrowser">
                                     <Boolean>false</Boolean>
                                 </field>
                                 <field name="outputResource">
-                                    <null/>
+                                    <String>${currentFileURL}</String>
                                 </field>
                                 <field name="openOtherLocationInBrowser">
                                     <Boolean>false</Boolean>

--- a/vicav.xpr
+++ b/vicav.xpr
@@ -10757,11 +10757,26 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                         <scenarioAssociation-array>
                             <scenarioAssociation>
                                 <field name="url">
-                                    <String>tools/802_tei_odd/vicav_profiles.odd</String>
+                                    <String>vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml</String>
                                 </field>
                                 <field name="scenarioIds">
                                     <list>
-                                        <String>injectSKOS2ODD</String>
+                                        <String>lingfeatures v1 to v2</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioTypes">
+                                    <list>
+                                        <String>XSL</String>
+                                    </list>
+                                </field>
+                            </scenarioAssociation>
+                            <scenarioAssociation>
+                                <field name="url">
+                                    <String>vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml</String>
+                                </field>
+                                <field name="scenarioIds">
+                                    <list>
+                                        <String>vicav_lingfeatures_add_ana</String>
                                     </list>
                                 </field>
                                 <field name="scenarioTypes">
@@ -10787,11 +10802,11 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                             </scenarioAssociation>
                             <scenarioAssociation>
                                 <field name="url">
-                                    <String>vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml</String>
+                                    <String>tools/802_tei_odd/vicav_profiles.odd</String>
                                 </field>
                                 <field name="scenarioIds">
                                     <list>
-                                        <String>lingfeatures v1 to v2</String>
+                                        <String>injectSKOS2ODD</String>
                                     </list>
                                 </field>
                                 <field name="scenarioTypes">
@@ -11642,6 +11657,89 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                     <null/>
                                 </field>
                                 <field name="name">
+                                    <String>injectSKOS2ODD</String>
+                                </field>
+                                <field name="baseURL">
+                                    <String></String>
+                                </field>
+                                <field name="footerURL">
+                                    <String></String>
+                                </field>
+                                <field name="fOPMethod">
+                                    <String>pdf</String>
+                                </field>
+                                <field name="fOProcessorName">
+                                    <String>Apache FOP</String>
+                                </field>
+                                <field name="headerURL">
+                                    <String></String>
+                                </field>
+                                <field name="inputXSLURL">
+                                    <String>${pdu}/tools/082_scripts_xsl/injectSKOS2ODD.xsl</String>
+                                </field>
+                                <field name="inputXMLURL">
+                                    <String>${currentFileURL}</String>
+                                </field>
+                                <field name="defaultScenario">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="isFOPPerforming">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="type">
+                                    <String>XSL</String>
+                                </field>
+                                <field name="saveAs">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="openInBrowser">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="outputResource">
+                                    <String>${cfne}</String>
+                                </field>
+                                <field name="openOtherLocationInBrowser">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="locationToOpenInBrowserURL">
+                                    <null/>
+                                </field>
+                                <field name="openInEditor">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInHTMLPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInXMLPane">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="showInSVGPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInResultSetPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="useXSLTInput">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="xsltParams">
+                                    <list/>
+                                </field>
+                                <field name="cascadingStylesheets">
+                                    <String-array/>
+                                </field>
+                                <field name="xslTransformer">
+                                    <String>Saxon-PE</String>
+                                </field>
+                                <field name="extensionURLs">
+                                    <String-array/>
+                                </field>
+                            </scenario>
+                            <scenario>
+                                <field name="advancedOptionsMap">
+                                    <null/>
+                                </field>
+                                <field name="name">
                                     <String>lingfeatures v1 to v2</String>
                                 </field>
                                 <field name="baseURL">
@@ -11891,7 +11989,7 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                     <null/>
                                 </field>
                                 <field name="name">
-                                    <String>injectSKOS2ODD</String>
+                                    <String>vicav_lingfeatures_add_ana</String>
                                 </field>
                                 <field name="baseURL">
                                     <String></String>
@@ -11909,7 +12007,7 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                     <String></String>
                                 </field>
                                 <field name="inputXSLURL">
-                                    <String>${pdu}/tools/082_scripts_xsl/injectSKOS2ODD.xsl</String>
+                                    <String>file:/home/zabraham/Development/vicav-content/tools/082_scripts_xsl/lingFeatures_add_semlib.xsl</String>
                                 </field>
                                 <field name="inputXMLURL">
                                     <String>${currentFileURL}</String>
@@ -11924,13 +12022,13 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
                                     <String>XSL</String>
                                 </field>
                                 <field name="saveAs">
-                                    <Boolean>true</Boolean>
+                                    <Boolean>false</Boolean>
                                 </field>
                                 <field name="openInBrowser">
                                     <Boolean>false</Boolean>
                                 </field>
                                 <field name="outputResource">
-                                    <String>${cfne}</String>
+                                    <null/>
                                 </field>
                                 <field name="openOtherLocationInBrowser">
                                     <Boolean>false</Boolean>

--- a/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
@@ -577,7 +577,7 @@
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w xml:id="wid_00320">āne</w>
+                        <w xml:id="wid_00320" ana="fvlib:perspron_1_sg">āne</w>
                      <w xml:id="wid_00321" join="right">məʕalləm</w>
                      <pc xml:id="id_pc_994">.</pc>
                   </quote>
@@ -639,9 +639,11 @@
                      <w xml:id="wid_00338" join="right">sayyāra</w>
                      <pc xml:id="id_pc_1060">?</pc>
                      <pc xml:id="id_pc_1062">–</pc>
+                     <phr ana="fvlib:pres_f_sg">
                         <w xml:id="wid_00339">ha</w>
                         
                         <w xml:id="wid_00340">hiyya</w>
+                     </phr>
                      <pc xml:id="id_pc_1067">.</pc>
                   </quote>
                </cit>
@@ -1901,7 +1903,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:existential" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p xml:id="id_p_12">
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -45,7 +40,7 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
@@ -88,7 +83,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s good.</quote>
                <cit type="translation">
@@ -146,7 +141,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -184,7 +179,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li</hi>
                      + <hi rend="italic">’ayy</hi> or <hi rend="italic">li</hi> + <hi rend="italic">’ayy</hi> +
@@ -220,7 +215,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī</hi> + <hi rend="italic">’ayna</hi>
                </note>
@@ -251,7 +246,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -295,7 +290,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from Cairo.</quote>
                <cit type="translation">
@@ -343,7 +338,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -387,7 +382,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -428,7 +423,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_much" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
@@ -459,7 +454,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters and three sons.</quote>
@@ -499,7 +494,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in K. A.</quote>
                <cit type="translation">
@@ -541,7 +536,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -599,7 +594,7 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
@@ -668,7 +663,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="semlib:here">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -695,7 +690,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:now">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -733,7 +728,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:today">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -761,7 +756,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:yesterday">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -781,7 +776,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:tomorrow">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -808,7 +803,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:last_year">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -842,7 +837,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="semlib:eight">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -869,7 +864,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eleven">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -903,7 +898,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:twelve">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -930,7 +925,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eighteen">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -960,7 +955,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="semlib:good">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -1005,7 +1000,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="semlib:white">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white car.</quote>
                <cit type="translation">
@@ -1061,7 +1056,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:black">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -1107,7 +1102,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:pink">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -1143,7 +1138,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:grey">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
@@ -1166,7 +1161,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:orange">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
@@ -1191,7 +1186,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semlib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -1223,7 +1218,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="semlib:to_do">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -1260,7 +1255,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_stay">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -1296,7 +1291,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_speak">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1323,7 +1318,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_rain">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -1342,7 +1337,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_open">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -1364,7 +1359,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_close">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -1386,7 +1381,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_take">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1423,7 +1418,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_give">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to him.</quote>
                <cit type="translation">
@@ -1476,7 +1471,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_see">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1508,7 +1503,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_want">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea please.</quote>
                <cit type="translation">
@@ -1546,7 +1541,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_bring">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with you. („here you are?“)</quote>
                <cit type="translation">
@@ -1583,7 +1578,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_have">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1619,7 +1614,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render English ‛since’.</note>
@@ -1655,7 +1650,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="semlib:women">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking bread.</quote>
                <cit type="translation">
@@ -1693,7 +1688,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:husband">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white car.</quote>
                <cit type="translation">
@@ -1729,7 +1724,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:friend">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -1766,7 +1761,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1799,7 +1794,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="semlib:being_unable">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1830,7 +1825,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:ability">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play chess? – Yes.</quote>
                <cit type="translation">
@@ -1860,7 +1855,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:possibility">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1879,7 +1874,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="semlib:a_little">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -45,31 +45,31 @@
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                         <w ana="semlib:who" xml:id="wid_00000" join="right">mǝnu</w>
-                     <w xml:id="wid_00001" join="right">hāḏa</w>
-                     <w xml:id="wid_00002" join="right">r</w>
+                         <w ana="semlib:who" xml:id="wid_00000">mǝnu</w>
+                     <w xml:id="wid_00001">hāḏa</w>
+                     <w xml:id="wid_00002">r</w>
                      <pc type="ws" xml:id="id_pc_52" join="right">-</pc>
-                     <w ana="semlib:man" xml:id="wid_00003" join="right">rǝǧǧāl</w>
+                     <w ana="semlib:man" xml:id="wid_00003">rǝǧǧāl</w>
                      <pc type="ws" xml:id="id_pc_54" join="right">?</pc>
-                     <w xml:id="wid_00004" join="right">–</w>
-                     <w ana="fvlib:perspron_3_sg_m" xml:id="wid_00005" join="right">huwwa</w>
-                     <w xml:id="wid_00006" join="right">ṣadīq</w>
-                     <w xml:id="id_w_1" join="right">i</w>
+                     <w xml:id="wid_00004">–</w>
+                     <w ana="fvlib:perspron_3_sg_m" xml:id="wid_00005">huwwa</w>
+                     <w xml:id="wid_00006">ṣadīq</w>
+                     <w xml:id="id_w_1">i</w>
                      <pc type="ws" xml:id="id_pc_61">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00007" join="right">Wer</w>
-                     <w xml:id="wid_00008" join="right">ist</w>
-                     <w xml:id="wid_00009" join="right">dieser</w>
-                     <w xml:id="wid_00010" join="right">Mann</w>
+                     <w xml:id="wid_00007">Wer</w>
+                     <w xml:id="wid_00008">ist</w>
+                     <w xml:id="wid_00009">dieser</w>
+                     <w xml:id="wid_00010">Mann</w>
                      <pc type="ws" xml:id="id_pc_70" join="right">?</pc>
-                     <w xml:id="wid_00011" join="right">–</w>
-                     <w xml:id="wid_00012" join="right">Er</w>
-                     <w xml:id="wid_00013" join="right">ist</w>
-                     <w xml:id="wid_00014" join="right">mein</w>
-                     <w xml:id="wid_00015" join="right">Freund</w>
+                     <w xml:id="wid_00011">–</w>
+                     <w xml:id="wid_00012">Er</w>
+                     <w xml:id="wid_00013">ist</w>
+                     <w xml:id="wid_00014">mein</w>
+                     <w xml:id="wid_00015">Freund</w>
                      <pc type="ws" xml:id="id_pc_81">.</pc>
                   </quote>
                </cit>
@@ -80,40 +80,40 @@
                      good.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w ana="fvlib:dempron_prox_f_sg" xml:id="wid_00021" join="right">hāḏi</w>
-                     <w ana="semlib:car" xml:id="wid_00022" join="right">siyyārat</w>
-                        <w ana="semlib:whose" xml:id="wid_00023" join="right">mǝnu</w>
+                     <w ana="fvlib:dempron_prox_f_sg" xml:id="wid_00021">hāḏi</w>
+                     <w ana="semlib:car" xml:id="wid_00022">siyyārat</w>
+                        <w ana="semlib:whose" xml:id="wid_00023">mǝnu</w>
                      <pc type="ws" xml:id="id_pc_105" join="right">?</pc>
-                     <w xml:id="wid_00024" join="right">–</w>
-                     <w xml:id="wid_00025" join="right">hāḏi</w>
-                     <w xml:id="wid_00026" join="right">siyyāratna</w>
+                     <w xml:id="wid_00024">–</w>
+                     <w xml:id="wid_00025">hāḏi</w>
+                     <w xml:id="wid_00026">siyyāratna</w>
                      <pc type="ws" xml:id="id_pc_112" join="right">,</pc>
-                     <w xml:id="wid_00027" join="right">hiyya</w>
-                     <w xml:id="wid_00028" join="right">ṣġayyra</w>
-                     <w xml:id="wid_00029" join="right">bass</w>
-                     <w xml:id="wid_00030" join="right">zēna</w>
+                     <w xml:id="wid_00027">hiyya</w>
+                     <w xml:id="wid_00028">ṣġayyra</w>
+                     <w xml:id="wid_00029">bass</w>
+                     <w xml:id="wid_00030">zēna</w>
                      <pc type="ws" xml:id="id_pc_121">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00031" join="right">Wessen</w>
-                     <w xml:id="wid_00032" join="right">Auto</w>
-                     <w xml:id="wid_00033" join="right">ist</w>
-                     <w xml:id="wid_00034" join="right">das</w>
+                     <w xml:id="wid_00031">Wessen</w>
+                     <w xml:id="wid_00032">Auto</w>
+                     <w xml:id="wid_00033">ist</w>
+                     <w xml:id="wid_00034">das</w>
                      <pc type="ws" xml:id="id_pc_130" join="right">?</pc>
-                     <w xml:id="wid_00035" join="right">–</w>
-                     <w xml:id="wid_00036" join="right">Das</w>
-                     <w xml:id="wid_00037" join="right">ist</w>
-                     <w xml:id="wid_00038" join="right">unser</w>
-                     <w xml:id="wid_00039" join="right">Auto</w>
+                     <w xml:id="wid_00035">–</w>
+                     <w xml:id="wid_00036">Das</w>
+                     <w xml:id="wid_00037">ist</w>
+                     <w xml:id="wid_00038">unser</w>
+                     <w xml:id="wid_00039">Auto</w>
                      <pc type="ws" xml:id="id_pc_141" join="right">.</pc>
-                     <w xml:id="wid_00040" join="right">Es</w>
-                     <w xml:id="wid_00041" join="right">ist</w>
-                     <w xml:id="wid_00042" join="right">klein</w>
+                     <w xml:id="wid_00040">Es</w>
+                     <w xml:id="wid_00041">ist</w>
+                     <w xml:id="wid_00042">klein</w>
                      <pc type="ws" xml:id="id_pc_148" join="right">,</pc>
-                     <w xml:id="wid_00043" join="right">aber</w>
-                     <w xml:id="wid_00044" join="right">gut</w>
+                     <w xml:id="wid_00043">aber</w>
+                     <w xml:id="wid_00044">gut</w>
                      <pc type="ws" xml:id="id_pc_153">.</pc>
                   </quote>
                </cit>
@@ -123,36 +123,36 @@
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00054" join="right">Fāṭma</w>
+                     <w xml:id="wid_00054">Fāṭma</w>
                      <pc type="ws" xml:id="id_pc_181" join="right">,</pc>
-                        <w ana="semlib:what" xml:id="wid_00055" join="right">ǝš</w>
+                        <w ana="semlib:what" xml:id="wid_00055">ǝš</w>
                      <pc type="ws" xml:id="id_pc_184" join="right">-</pc>
-                     <w xml:id="wid_00056" join="right">da</w>
+                     <w xml:id="wid_00056">da</w>
                      <pc type="ws" xml:id="id_pc_186" join="right">-</pc>
-                     <w xml:id="wid_00057" join="right">ssawwīn</w>
-                     <w xml:id="wid_00058" join="right">hassa</w>
+                     <w xml:id="wid_00057">ssawwīn</w>
+                     <w xml:id="wid_00058">hassa</w>
                      <pc type="ws" xml:id="id_pc_190" join="right">?</pc>
-                     <w xml:id="wid_00059" join="right">–</w>
-                     <w xml:id="wid_00060" join="right">ʔašūf</w>
-                     <w xml:id="wid_00061" join="right">ǝt</w>
+                     <w xml:id="wid_00059">–</w>
+                     <w xml:id="wid_00060">ʔašūf</w>
+                     <w xml:id="wid_00061">ǝt</w>
                      <pc type="ws" xml:id="id_pc_197" join="right">-</pc>
-                     <w ana="semlib:TV" xml:id="wid_00062" join="right">talfizyōn</w>
+                     <w ana="semlib:TV" xml:id="wid_00062">talfizyōn</w>
                      <pc type="ws" xml:id="id_pc_199">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00063" join="right">Fatima</w>
+                     <w xml:id="wid_00063">Fatima</w>
                      <pc type="ws" xml:id="id_pc_202" join="right">,</pc>
-                     <w xml:id="wid_00064" join="right">was</w>
-                     <w xml:id="wid_00065" join="right">machst</w>
-                     <w xml:id="wid_00066" join="right">du</w>
-                     <w xml:id="wid_00067" join="right">gerade</w>
+                     <w xml:id="wid_00064">was</w>
+                     <w xml:id="wid_00065">machst</w>
+                     <w xml:id="wid_00066">du</w>
+                     <w xml:id="wid_00067">gerade</w>
                      <pc type="ws" xml:id="id_pc_211" join="right">?</pc>
-                     <w xml:id="wid_00068" join="right">–</w>
-                     <w xml:id="wid_00069" join="right">Ich</w>
-                     <w xml:id="wid_00070" join="right">schaue</w>
-                     <w xml:id="wid_00071" join="right">fern</w>
+                     <w xml:id="wid_00068">–</w>
+                     <w xml:id="wid_00069">Ich</w>
+                     <w xml:id="wid_00070">schaue</w>
+                     <w xml:id="wid_00071">fern</w>
                      <pc type="ws" xml:id="id_pc_220">.</pc>
                   </quote>
                </cit>
@@ -165,29 +165,29 @@
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:why" xml:id="wid_00079" join="right">lēš</w>
-                     <w xml:id="wid_00080" join="right">ma</w>
-                     <w xml:id="wid_00081" join="right">ʔǝǧa</w>
+                        <w ana="semlib:why" xml:id="wid_00079">lēš</w>
+                     <w xml:id="wid_00080">ma</w>
+                     <w xml:id="wid_00081">ʔǝǧa</w>
                      <pc type="ws" xml:id="id_pc_251" join="right">?</pc>
-                     <w xml:id="wid_00082" join="right">–</w>
-                     <w xml:id="wid_00083" join="right">ma</w>
-                     <w xml:id="wid_00084" join="right">ʔaʕruf</w>
+                     <w xml:id="wid_00082">–</w>
+                     <w xml:id="wid_00083">ma</w>
+                     <w xml:id="wid_00084">ʔaʕruf</w>
                      <pc type="ws" xml:id="id_pc_258">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00085" join="right">Warum</w>
-                     <w xml:id="wid_00086" join="right">ist</w>
-                     <w xml:id="wid_00087" join="right">er</w>
-                     <w xml:id="wid_00088" join="right">nicht</w>
-                     <w xml:id="wid_00089" join="right">gekommen</w>
+                     <w xml:id="wid_00085">Warum</w>
+                     <w xml:id="wid_00086">ist</w>
+                     <w xml:id="wid_00087">er</w>
+                     <w xml:id="wid_00088">nicht</w>
+                     <w xml:id="wid_00089">gekommen</w>
                      <pc type="ws" xml:id="id_pc_269" join="right">?</pc>
-                     <w xml:id="wid_00090" join="right">–</w>
-                     <w xml:id="wid_00091" join="right">Ich</w>
-                     <w xml:id="wid_00092" join="right">weiß</w>
-                     <w xml:id="wid_00093" join="right">es</w>
-                     <w xml:id="wid_00094" join="right">nicht</w>
+                     <w xml:id="wid_00090">–</w>
+                     <w xml:id="wid_00091">Ich</w>
+                     <w xml:id="wid_00092">weiß</w>
+                     <w xml:id="wid_00093">es</w>
+                     <w xml:id="wid_00094">nicht</w>
                      <pc type="ws" xml:id="id_pc_280">.</pc>
                   </quote>
                </cit>
@@ -200,28 +200,28 @@
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:where" xml:id="wid_00100" join="right">wēn</w>
-                     <w xml:id="wid_00101" join="right">ǝl</w>
+                        <w ana="semlib:where" xml:id="wid_00100">wēn</w>
+                     <w xml:id="wid_00101">ǝl</w>
                      <pc type="ws" xml:id="id_pc_304" join="right">-</pc>
-                     <w xml:id="wid_00102" join="right">mōbāyl</w>
-                     <w xml:id="wid_00103" join="right">mālti</w>
+                     <w xml:id="wid_00102">mōbāyl</w>
+                     <w xml:id="wid_00103">mālti</w>
                      <pc type="ws" xml:id="id_pc_308" join="right">?</pc>
-                     <w xml:id="wid_00104" join="right">–</w>
-                     <w xml:id="wid_00105" join="right">hayyāta</w>
+                     <w xml:id="wid_00104">–</w>
+                     <w xml:id="wid_00105">hayyāta</w>
                      <pc type="ws" xml:id="id_pc_313">!</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00106" join="right">Wo</w>
-                     <w xml:id="wid_00107" join="right">ist</w>
-                     <w xml:id="wid_00108" join="right">mein</w>
-                     <w xml:id="wid_00109" join="right">Handy</w>
+                     <w xml:id="wid_00106">Wo</w>
+                     <w xml:id="wid_00107">ist</w>
+                     <w xml:id="wid_00108">mein</w>
+                     <w xml:id="wid_00109">Handy</w>
                      <pc type="ws" xml:id="id_pc_322" join="right">?</pc>
-                     <w xml:id="wid_00110" join="right">–</w>
-                     <w xml:id="wid_00111" join="right">Da</w>
-                     <w xml:id="wid_00112" join="right">ist</w>
-                     <w xml:id="wid_00113" join="right">es</w>
+                     <w xml:id="wid_00110">–</w>
+                     <w xml:id="wid_00111">Da</w>
+                     <w xml:id="wid_00112">ist</w>
+                     <w xml:id="wid_00113">es</w>
                      <pc type="ws" xml:id="id_pc_331">!</pc>
                   </quote>
                </cit>
@@ -231,39 +231,39 @@
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:where_to" xml:id="wid_00119" join="right">wēn</w>
-                     <w xml:id="wid_00120" join="right">rāḥ</w>
-                     <w xml:id="wid_00121" join="right">ǝtrūḥ</w>
+                        <w ana="semlib:where_to" xml:id="wid_00119">wēn</w>
+                     <w xml:id="wid_00120">rāḥ</w>
+                     <w xml:id="wid_00121">ǝtrūḥ</w>
                      <pc type="ws" xml:id="id_pc_357" join="right">?</pc>
-                     <w xml:id="wid_00122" join="right">/</w>
-                     <w xml:id="wid_00123" join="right">wēn</w>
-                     <w xml:id="wid_00124" join="right">rāḥ</w>
-                     <w xml:id="wid_00125" join="right">ǝtrūḥīn</w>
+                     <w xml:id="wid_00122">/</w>
+                     <w xml:id="wid_00123">wēn</w>
+                     <w xml:id="wid_00124">rāḥ</w>
+                     <w xml:id="wid_00125">ǝtrūḥīn</w>
                      <pc type="ws" xml:id="id_pc_366" join="right">?</pc>
-                     <w xml:id="wid_00126" join="right">–</w>
-                     <w xml:id="wid_00127" join="right">rāḥ</w>
-                     <w xml:id="wid_00128" join="right">ǝrūḥ</w>
-                     <w xml:id="wid_00129" join="right">ʕala</w>
-                     <w xml:id="wid_00130" join="right">l</w>
+                     <w xml:id="wid_00126">–</w>
+                     <w xml:id="wid_00127">rāḥ</w>
+                     <w xml:id="wid_00128">ǝrūḥ</w>
+                     <w xml:id="wid_00129">ʕala</w>
+                     <w xml:id="wid_00130">l</w>
                      <pc type="ws" xml:id="id_pc_377" join="right">-</pc>
-                     <w xml:id="wid_00131" join="right">bēt</w>
+                     <w xml:id="wid_00131">bēt</w>
                      <pc type="ws" xml:id="id_pc_379">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00132" join="right">Wohin</w>
-                     <w xml:id="wid_00133" join="right">gehst</w>
-                     <w xml:id="wid_00134" join="right">du</w>
+                     <w xml:id="wid_00132">Wohin</w>
+                     <w xml:id="wid_00133">gehst</w>
+                     <w xml:id="wid_00134">du</w>
                      <pc type="ws" xml:id="id_pc_387" join="right">(</pc>
-                     <w xml:id="wid_00135" join="right">f/m</w>
+                     <w xml:id="wid_00135">f/m</w>
                      <pc type="ws" xml:id="id_pc_389" join="right">)</pc>
                      <pc type="ws" xml:id="id_pc_390" join="right">?</pc>
-                     <w xml:id="wid_00136" join="right">–</w>
-                     <w xml:id="wid_00137" join="right">Ich</w>
-                     <w xml:id="wid_00138" join="right">gehe</w>
-                     <w xml:id="wid_00139" join="right">nach</w>
-                     <w xml:id="wid_00140" join="right">Hause</w>
+                     <w xml:id="wid_00136">–</w>
+                     <w xml:id="wid_00137">Ich</w>
+                     <w xml:id="wid_00138">gehe</w>
+                     <w xml:id="wid_00139">nach</w>
+                     <w xml:id="wid_00140">Hause</w>
                      <pc type="ws" xml:id="id_pc_401">.</pc>
                   </quote>
                </cit>
@@ -274,42 +274,42 @@
                      Cairo.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:where_from" xml:id="wid_00148" join="right">ǝmmēn</w>
-                     <w ana="fvlib:perspron_2_sg_m" xml:id="wid_00149" join="right">ǝnta</w>
-                     <w xml:id="wid_00150" join="right">/</w>
-                     <w ana="fvlib:perspron_2_sg_f" xml:id="wid_00151" join="right">ǝnti</w>
-                     <w xml:id="wid_00152" join="right">/</w>
-                     <w ana="fvlib:perspron_2_pl" xml:id="wid_00153" join="right">ǝntu</w>
+                        <w ana="semlib:where_from" xml:id="wid_00148">ǝmmēn</w>
+                     <w ana="fvlib:perspron_2_sg_m" xml:id="wid_00149">ǝnta</w>
+                     <w xml:id="wid_00150">/</w>
+                     <w ana="fvlib:perspron_2_sg_f" xml:id="wid_00151">ǝnti</w>
+                     <w xml:id="wid_00152">/</w>
+                     <w ana="fvlib:perspron_2_pl" xml:id="wid_00153">ǝntu</w>
                      <pc type="ws" xml:id="id_pc_439" join="right">?</pc>
-                     <w xml:id="wid_00154" join="right">–</w>
-                     <w ana="fvlib:perspron_1_sg" xml:id="wid_00155" join="right">ʔāni</w>
-                     <w xml:id="wid_00156" join="right">mǝn</w>
-                     <w xml:id="wid_00157" join="right">baġdād</w>
+                     <w xml:id="wid_00154">–</w>
+                     <w ana="fvlib:perspron_1_sg" xml:id="wid_00155">ʔāni</w>
+                     <w xml:id="wid_00156">mǝn</w>
+                     <w xml:id="wid_00157">baġdād</w>
                      <pc type="ws" xml:id="id_pc_448" join="right">.</pc>
-                     <w xml:id="wid_00158" join="right">/</w>
-                     <w ana="fvlib:perspron_1_pl" xml:id="wid_00159" join="right">ǝḥna</w>
-                     <w xml:id="wid_00160" join="right">mǝn</w>
-                     <w xml:id="wid_00161" join="right">baġdād</w>
+                     <w xml:id="wid_00158">/</w>
+                     <w ana="fvlib:perspron_1_pl" xml:id="wid_00159">ǝḥna</w>
+                     <w xml:id="wid_00160">mǝn</w>
+                     <w xml:id="wid_00161">baġdād</w>
                      <pc type="ws" xml:id="id_pc_457">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00162" join="right">Woher</w>
-                     <w xml:id="wid_00163" join="right">bist</w>
-                     <w xml:id="wid_00164" join="right">du</w>
+                     <w xml:id="wid_00162">Woher</w>
+                     <w xml:id="wid_00163">bist</w>
+                     <w xml:id="wid_00164">du</w>
                      <pc type="ws" xml:id="id_pc_464" join="right">?</pc>
-                     <w xml:id="wid_00165" join="right">/Woher</w>
-                     <w xml:id="wid_00166" join="right">seid</w>
-                     <w xml:id="wid_00167" join="right">ihr</w>
+                     <w xml:id="wid_00165">/Woher</w>
+                     <w xml:id="wid_00166">seid</w>
+                     <w xml:id="wid_00167">ihr</w>
                      <pc type="ws" xml:id="id_pc_470" join="right">?</pc>
-                     <w xml:id="wid_00168" join="right">–</w>
-                     <w xml:id="wid_00169" join="right">Ich</w>
-                     <w xml:id="wid_00170" join="right">bin</w>
-                     <w xml:id="wid_00171" join="right">aus…</w>
-                     <w xml:id="wid_00172" join="right">/</w>
-                     <w xml:id="wid_00173" join="right">Wir</w>
-                     <w xml:id="wid_00174" join="right">sind</w>
+                     <w xml:id="wid_00168">–</w>
+                     <w xml:id="wid_00169">Ich</w>
+                     <w xml:id="wid_00170">bin</w>
+                     <w xml:id="wid_00171">aus…</w>
+                     <w xml:id="wid_00172">/</w>
+                     <w xml:id="wid_00173">Wir</w>
+                     <w xml:id="wid_00174">sind</w>
                      <w xml:id="wid_00175">aus…</w>
                   </quote>
                </cit>
@@ -319,36 +319,36 @@
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00185" join="right">ya</w>
-                     <w xml:id="wid_00186" join="right">Fāṭma</w>
+                     <w xml:id="wid_00185">ya</w>
+                     <w xml:id="wid_00186">Fāṭma</w>
                      <pc type="ws" xml:id="id_pc_520" join="right">,</pc>
-                        <w ana="semlib:when" xml:id="wid_00187" join="right">ǝšwakǝt</w>
-                     <w xml:id="wid_00188" join="right">šǝfti</w>
-                     <w xml:id="wid_00189" join="right">Mḥammad</w>
+                        <w ana="semlib:when" xml:id="wid_00187">ǝšwakǝt</w>
+                     <w xml:id="wid_00188">šǝfti</w>
+                     <w xml:id="wid_00189">Mḥammad</w>
                      <pc type="ws" xml:id="id_pc_527" join="right">?</pc>
-                     <w xml:id="wid_00190" join="right">–</w>
-                     <w xml:id="wid_00191" join="right">šǝfta</w>
-                     <w xml:id="wid_00192" join="right">l</w>
+                     <w xml:id="wid_00190">–</w>
+                     <w xml:id="wid_00191">šǝfta</w>
+                     <w xml:id="wid_00192">l</w>
                      <pc type="ws" xml:id="id_pc_534" join="right">-</pc>
-                     <w xml:id="wid_00193" join="right">bārḥa</w>
+                     <w xml:id="wid_00193">bārḥa</w>
                      <pc type="ws" xml:id="id_pc_536">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00194" join="right">Fatima</w>
+                     <w xml:id="wid_00194">Fatima</w>
                      <pc type="ws" xml:id="id_pc_539" join="right">,</pc>
-                     <w xml:id="wid_00195" join="right">wann</w>
-                     <w xml:id="wid_00196" join="right">hast</w>
-                     <w xml:id="wid_00197" join="right">du</w>
-                     <w xml:id="wid_00198" join="right">Muhammad</w>
-                     <w xml:id="wid_00199" join="right">gesehen</w>
+                     <w xml:id="wid_00195">wann</w>
+                     <w xml:id="wid_00196">hast</w>
+                     <w xml:id="wid_00197">du</w>
+                     <w xml:id="wid_00198">Muhammad</w>
+                     <w xml:id="wid_00199">gesehen</w>
                      <pc type="ws" xml:id="id_pc_550" join="right">?</pc>
-                     <w xml:id="wid_00200" join="right">–</w>
-                     <w xml:id="wid_00201" join="right">Ich</w>
-                     <w xml:id="wid_00202" join="right">sah</w>
-                     <w xml:id="wid_00203" join="right">ihn</w>
-                     <w xml:id="wid_00204" join="right">gestern</w>
+                     <w xml:id="wid_00200">–</w>
+                     <w xml:id="wid_00201">Ich</w>
+                     <w xml:id="wid_00202">sah</w>
+                     <w xml:id="wid_00203">ihn</w>
+                     <w xml:id="wid_00204">gestern</w>
                      <pc type="ws" xml:id="id_pc_561">.</pc>
                   </quote>
                </cit>
@@ -358,38 +358,38 @@
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:how" xml:id="wid_00212" join="right">ǝšlōn</w>
-                     <w xml:id="wid_00213" join="right">ak</w>
-                     <w xml:id="wid_00214" join="right">/</w>
-                        <w xml:id="wid_00215" join="right">ǝšlōn</w>
-                     <w xml:id="wid_00216" join="right">ǝč</w>
+                        <w ana="semlib:how" xml:id="wid_00212">ǝšlōn</w>
+                     <w xml:id="wid_00213">ak</w>
+                     <w xml:id="wid_00214">/</w>
+                        <w xml:id="wid_00215">ǝšlōn</w>
+                     <w xml:id="wid_00216">ǝč</w>
                      <pc type="ws" xml:id="id_pc_592" join="right">?</pc>
-                     <w xml:id="wid_00217" join="right">–</w>
-                     <w xml:id="wid_00218" join="right">zēn</w>
-                     <w xml:id="wid_00219" join="right">/</w>
-                     <w xml:id="wid_00220" join="right">zēna</w>
+                     <w xml:id="wid_00217">–</w>
+                     <w xml:id="wid_00218">zēn</w>
+                     <w xml:id="wid_00219">/</w>
+                     <w xml:id="wid_00220">zēna</w>
                      <pc type="ws" xml:id="id_pc_601" join="right">,</pc>
-                     <w xml:id="wid_00221" join="right">l</w>
+                     <w xml:id="wid_00221">l</w>
                      <pc type="ws" xml:id="id_pc_604" join="right">-</pc>
-                     <w xml:id="wid_00222" join="right">ḥamdilla</w>
+                     <w xml:id="wid_00222">ḥamdilla</w>
                      <pc type="ws" xml:id="id_pc_606">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00223" join="right">Wie</w>
-                     <w xml:id="wid_00224" join="right">geht</w>
-                     <w xml:id="wid_00225" join="right">es</w>
-                     <w xml:id="wid_00226" join="right">dir</w>
+                     <w xml:id="wid_00223">Wie</w>
+                     <w xml:id="wid_00224">geht</w>
+                     <w xml:id="wid_00225">es</w>
+                     <w xml:id="wid_00226">dir</w>
                      <pc type="ws" xml:id="id_pc_616" join="right">(</pc>
-                     <w xml:id="wid_00227" join="right">m/f</w>
+                     <w xml:id="wid_00227">m/f</w>
                      <pc type="ws" xml:id="id_pc_618" join="right">)</pc>
                      <pc type="ws" xml:id="id_pc_619" join="right">?</pc>
-                     <w xml:id="wid_00228" join="right">–</w>
-                     <w xml:id="wid_00229" join="right">Mir</w>
-                     <w xml:id="wid_00230" join="right">geht</w>
-                     <w xml:id="wid_00231" join="right">es</w>
-                     <w xml:id="wid_00232" join="right">gut</w>
+                     <w xml:id="wid_00228">–</w>
+                     <w xml:id="wid_00229">Mir</w>
+                     <w xml:id="wid_00230">geht</w>
+                     <w xml:id="wid_00231">es</w>
+                     <w xml:id="wid_00232">gut</w>
                      <pc type="ws" xml:id="id_pc_630">.</pc>
                   </quote>
                </cit>
@@ -399,33 +399,33 @@
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:how_much" xml:id="wid_00239" join="right">bēš</w>
-                     <w xml:id="wid_00240" join="right">nuṣṣ</w>
-                     <w xml:id="wid_00241" join="right">kēlu</w>
-                     <w xml:id="wid_00242" join="right">nūmi</w>
-                     <w ana="semlib:lemon" xml:id="wid_00243" join="right">ḥāmuð̣</w>
+                        <w ana="semlib:how_much" xml:id="wid_00239">bēš</w>
+                     <w xml:id="wid_00240">nuṣṣ</w>
+                     <w xml:id="wid_00241">kēlu</w>
+                     <w xml:id="wid_00242">nūmi</w>
+                     <w ana="semlib:lemon" xml:id="wid_00243">ḥāmuð̣</w>
                      <pc type="ws" xml:id="id_pc_660" join="right">.</pc>
-                     <w xml:id="wid_00244" join="right">–</w>
-                     <w xml:id="wid_00245" join="right">sǝʕra</w>
-                     <w xml:id="wid_00246" join="right">ʔarbaʕ</w>
-                     <w xml:id="wid_00247" join="right">danānīr</w>
-                     <w xml:id="wid_00248" join="right">w</w>
+                     <w xml:id="wid_00244">–</w>
+                     <w xml:id="wid_00245">sǝʕra</w>
+                     <w xml:id="wid_00246">ʔarbaʕ</w>
+                     <w xml:id="wid_00247">danānīr</w>
+                     <w xml:id="wid_00248">w</w>
                      <pc type="ws" xml:id="id_pc_671" join="right">-</pc>
-                     <w xml:id="wid_00249" join="right">nuṣṣ</w>
+                     <w xml:id="wid_00249">nuṣṣ</w>
                      <pc type="ws" xml:id="id_pc_673">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00250" join="right">Wieviel</w>
-                     <w xml:id="wid_00251" join="right">kostet</w>
-                     <w xml:id="wid_00252" join="right">½</w>
-                     <w xml:id="wid_00253" join="right">Kilo</w>
-                     <w xml:id="wid_00254" join="right">Zitronen</w>
+                     <w xml:id="wid_00250">Wieviel</w>
+                     <w xml:id="wid_00251">kostet</w>
+                     <w xml:id="wid_00252">½</w>
+                     <w xml:id="wid_00253">Kilo</w>
+                     <w xml:id="wid_00254">Zitronen</w>
                      <pc type="ws" xml:id="id_pc_684" join="right">?</pc>
-                     <w xml:id="wid_00255" join="right">–</w>
-                     <w xml:id="wid_00256" join="right">Es</w>
-                     <w xml:id="wid_00257" join="right">kostet</w>
+                     <w xml:id="wid_00255">–</w>
+                     <w xml:id="wid_00256">Es</w>
+                     <w xml:id="wid_00257">kostet</w>
                      <w xml:id="wid_00258">…</w>
                   </quote>
                </cit>
@@ -437,40 +437,40 @@
                      and three sons.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:how_many" xml:id="wid_00265" join="right">ǝšgadd</w>
-                     <w xml:id="wid_00266" join="right">ʕǝddǝč</w>
-                     <w xml:id="wid_00267" join="right">ǧahhāl</w>
+                        <w ana="semlib:how_many" xml:id="wid_00265">ǝšgadd</w>
+                     <w xml:id="wid_00266">ʕǝddǝč</w>
+                     <w xml:id="wid_00267">ǧahhāl</w>
                      <pc type="ws" xml:id="id_pc_723" join="right">?</pc>
-                     <w xml:id="wid_00268" join="right">/</w>
-                        <w xml:id="wid_00269" join="right">čam</w>
-                     <w xml:id="wid_00270" join="right">ǧāhǝl</w>
-                     <w xml:id="wid_00271" join="right">ʕǝndǝč</w>
+                     <w xml:id="wid_00268">/</w>
+                        <w xml:id="wid_00269">čam</w>
+                     <w xml:id="wid_00270">ǧāhǝl</w>
+                     <w xml:id="wid_00271">ʕǝndǝč</w>
                      <pc type="ws" xml:id="id_pc_732" join="right">?</pc>
-                     <w xml:id="wid_00272" join="right">–</w>
-                     <w xml:id="wid_00273" join="right">ʕǝddi</w>
-                     <w xml:id="wid_00274" join="right">bǝntēn</w>
-                     <w xml:id="wid_00275" join="right">wǝ</w>
+                     <w xml:id="wid_00272">–</w>
+                     <w xml:id="wid_00273">ʕǝddi</w>
+                     <w xml:id="wid_00274">bǝntēn</w>
+                     <w xml:id="wid_00275">wǝ</w>
                      <pc type="ws" xml:id="id_pc_741" join="right">-</pc>
-                     <w ana="semlib:three #vt_phon_CA_th" xml:id="wid_00276" join="right">tlaṯ</w>
-                     <w xml:id="wid_00277" join="right">wǝlǝd</w>
+                     <w ana="semlib:three #vt_phon_CA_th" xml:id="wid_00276">tlaṯ</w>
+                     <w xml:id="wid_00277">wǝlǝd</w>
                      <pc type="ws" xml:id="id_pc_745">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00278" join="right">Wieviele</w>
-                     <w xml:id="wid_00279" join="right">Kinder</w>
-                     <w xml:id="wid_00280" join="right">hast</w>
-                     <w xml:id="wid_00281" join="right">du</w>
+                     <w xml:id="wid_00278">Wieviele</w>
+                     <w xml:id="wid_00279">Kinder</w>
+                     <w xml:id="wid_00280">hast</w>
+                     <w xml:id="wid_00281">du</w>
                      <pc type="ws" xml:id="id_pc_754" join="right">?</pc>
-                     <w xml:id="wid_00282" join="right">–</w>
-                     <w xml:id="wid_00283" join="right">Ich</w>
-                     <w xml:id="wid_00284" join="right">habe</w>
-                     <w xml:id="wid_00285" join="right">zwei</w>
-                     <w xml:id="wid_00286" join="right">Töchter</w>
-                     <w xml:id="wid_00287" join="right">und</w>
-                     <w xml:id="wid_00288" join="right">drei</w>
-                     <w xml:id="wid_00289" join="right">Söhne</w>
+                     <w xml:id="wid_00282">–</w>
+                     <w xml:id="wid_00283">Ich</w>
+                     <w xml:id="wid_00284">habe</w>
+                     <w xml:id="wid_00285">zwei</w>
+                     <w xml:id="wid_00286">Töchter</w>
+                     <w xml:id="wid_00287">und</w>
+                     <w xml:id="wid_00288">drei</w>
+                     <w xml:id="wid_00289">Söhne</w>
                      <pc type="ws" xml:id="id_pc_771">.</pc>
                   </quote>
                </cit>
@@ -480,38 +480,38 @@
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00297" join="right">ǝb</w>
+                     <w xml:id="wid_00297">ǝb</w>
                      <pc type="ws" xml:id="id_pc_794" join="right">-</pc>
-                        <w ana="semlib:which" xml:id="wid_00298" join="right">ʔayy</w>
-                     <w xml:id="wid_00299" join="right">manṭiqa</w>
-                     <w xml:id="wid_00300" join="right">tsuknūn</w>
+                        <w ana="semlib:which" xml:id="wid_00298">ʔayy</w>
+                     <w xml:id="wid_00299">manṭiqa</w>
+                     <w xml:id="wid_00300">tsuknūn</w>
                      <pc type="ws" xml:id="id_pc_800" join="right">?</pc>
-                     <w xml:id="wid_00301" join="right">/</w>
-                     <w xml:id="wid_00302" join="right">sāknīn</w>
+                     <w xml:id="wid_00301">/</w>
+                     <w xml:id="wid_00302">sāknīn</w>
                      <pc type="ws" xml:id="id_pc_805" join="right">?</pc>
-                     <w xml:id="wid_00303" join="right">–</w>
-                     <w xml:id="wid_00304" join="right">nǝskun</w>
-                     <w xml:id="wid_00305" join="right">bǝ</w>
+                     <w xml:id="wid_00303">–</w>
+                     <w xml:id="wid_00304">nǝskun</w>
+                     <w xml:id="wid_00305">bǝ</w>
                      <pc type="ws" xml:id="id_pc_812" join="right">-</pc>
-                     <w xml:id="wid_00306" join="right">manṭiqat</w>
-                     <w xml:id="wid_00307" join="right">ǝl</w>
+                     <w xml:id="wid_00306">manṭiqat</w>
+                     <w xml:id="wid_00307">ǝl</w>
                      <pc type="ws" xml:id="id_pc_816" join="right">-</pc>
-                     <w xml:id="wid_00308" join="right">mustanṣirīya</w>
+                     <w xml:id="wid_00308">mustanṣirīya</w>
                      <pc type="ws" xml:id="id_pc_818">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00309" join="right">In</w>
-                     <w xml:id="wid_00310" join="right">welchem</w>
-                     <w xml:id="wid_00311" join="right">Viertel/Bezirk</w>
-                     <w xml:id="wid_00312" join="right">wohnt</w>
-                     <w xml:id="wid_00313" join="right">ihr</w>
+                     <w xml:id="wid_00309">In</w>
+                     <w xml:id="wid_00310">welchem</w>
+                     <w xml:id="wid_00311">Viertel/Bezirk</w>
+                     <w xml:id="wid_00312">wohnt</w>
+                     <w xml:id="wid_00313">ihr</w>
                      <pc type="ws" xml:id="id_pc_829" join="right">?</pc>
-                     <w xml:id="wid_00314" join="right">–</w>
-                     <w xml:id="wid_00315" join="right">Wir</w>
-                     <w xml:id="wid_00316" join="right">wohnen</w>
-                     <w xml:id="wid_00317" join="right">in</w>
+                     <w xml:id="wid_00314">–</w>
+                     <w xml:id="wid_00315">Wir</w>
+                     <w xml:id="wid_00316">wohnen</w>
+                     <w xml:id="wid_00317">in</w>
                      <w xml:id="wid_00318">…</w>
                   </quote>
                </cit>
@@ -524,30 +524,30 @@
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00325" join="right">mǝnu</w>
-                        <w ana="fvlib:dempron_prox_m_sg" xml:id="wid_00326" join="right">hāḏa</w>
-                     <w xml:id="wid_00327" join="right">r</w>
+                     <w xml:id="wid_00325">mǝnu</w>
+                        <w ana="fvlib:dempron_prox_m_sg" xml:id="wid_00326">hāḏa</w>
+                     <w xml:id="wid_00327">r</w>
                      <pc type="ws" xml:id="id_pc_876" join="right">-</pc>
-                     <w xml:id="wid_00328" join="right">rǝǧǧāl</w>
+                     <w xml:id="wid_00328">rǝǧǧāl</w>
                      <pc type="ws" xml:id="id_pc_878" join="right">?</pc>
-                     <w xml:id="wid_00329" join="right">–</w>
-                     <w xml:id="wid_00330" join="right">huwwa</w>
-                     <w xml:id="wid_00331" join="right">ṣadīqi</w>
+                     <w xml:id="wid_00329">–</w>
+                     <w xml:id="wid_00330">huwwa</w>
+                     <w xml:id="wid_00331">ṣadīqi</w>
                      <pc type="ws" xml:id="id_pc_885">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00332" join="right">Wer</w>
-                     <w xml:id="wid_00333" join="right">ist</w>
-                     <w xml:id="wid_00334" join="right">dieser</w>
-                     <w xml:id="wid_00335" join="right">Mann</w>
+                     <w xml:id="wid_00332">Wer</w>
+                     <w xml:id="wid_00333">ist</w>
+                     <w xml:id="wid_00334">dieser</w>
+                     <w xml:id="wid_00335">Mann</w>
                      <pc type="ws" xml:id="id_pc_894" join="right">?</pc>
-                     <w xml:id="wid_00336" join="right">–</w>
-                     <w xml:id="wid_00337" join="right">Er</w>
-                     <w xml:id="wid_00338" join="right">ist</w>
-                     <w xml:id="wid_00339" join="right">mein</w>
-                     <w xml:id="wid_00340" join="right">Freund</w>
+                     <w xml:id="wid_00336">–</w>
+                     <w xml:id="wid_00337">Er</w>
+                     <w xml:id="wid_00338">ist</w>
+                     <w xml:id="wid_00339">mein</w>
+                     <w xml:id="wid_00340">Freund</w>
                      <pc type="ws" xml:id="id_pc_905">.</pc>
                   </quote>
                </cit>
@@ -563,9 +563,9 @@
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00346" join="right">Ich</w>
-                     <w xml:id="wid_00347" join="right">bin</w>
-                     <w xml:id="wid_00348" join="right">Lehrer</w>
+                     <w xml:id="wid_00346">Ich</w>
+                     <w xml:id="wid_00347">bin</w>
+                     <w xml:id="wid_00348">Lehrer</w>
                      <pc type="ws" xml:id="id_pc_939">.</pc>
                   </quote>
                </cit>
@@ -578,28 +578,28 @@
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00349" join="right">wēn</w>
-                     <w xml:id="wid_00350" join="right">ǝl</w>
+                     <w xml:id="wid_00349">wēn</w>
+                     <w xml:id="wid_00350">ǝl</w>
                      <pc type="ws" xml:id="id_pc_960" join="right">-</pc>
-                     <w xml:id="wid_00351" join="right">mōbāyl</w>
-                     <w xml:id="wid_00352" join="right">mālti</w>
+                     <w xml:id="wid_00351">mōbāyl</w>
+                     <w xml:id="wid_00352">mālti</w>
                      <pc type="ws" xml:id="id_pc_964" join="right">?</pc>
-                     <w xml:id="wid_00353" join="right">–</w>
-                        <w ana="fvlib:pres_m_sg" xml:id="wid_00354" join="right">hayyāta</w>
+                     <w xml:id="wid_00353">–</w>
+                        <w ana="fvlib:pres_m_sg" xml:id="wid_00354">hayyāta</w>
                      <pc type="ws" xml:id="id_pc_969">!</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00355" join="right">Wo</w>
-                     <w xml:id="wid_00356" join="right">ist</w>
-                     <w xml:id="wid_00357" join="right">mein</w>
-                     <w xml:id="wid_00358" join="right">Handy</w>
+                     <w xml:id="wid_00355">Wo</w>
+                     <w xml:id="wid_00356">ist</w>
+                     <w xml:id="wid_00357">mein</w>
+                     <w xml:id="wid_00358">Handy</w>
                      <pc type="ws" xml:id="id_pc_978" join="right">?</pc>
-                     <w xml:id="wid_00359" join="right">–</w>
-                     <w xml:id="wid_00360" join="right">Hier</w>
-                     <w xml:id="wid_00361" join="right">ist</w>
-                     <w xml:id="wid_00362" join="right">es</w>
+                     <w xml:id="wid_00359">–</w>
+                     <w xml:id="wid_00360">Hier</w>
+                     <w xml:id="wid_00361">ist</w>
+                     <w xml:id="wid_00362">es</w>
                      <pc type="ws" xml:id="id_pc_987">.</pc>
                   </quote>
                </cit>
@@ -612,15 +612,15 @@
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00363" join="right">Wo</w>
-                     <w xml:id="wid_00364" join="right">mist</w>
-                     <w xml:id="wid_00365" join="right">das</w>
-                     <w xml:id="wid_00366" join="right">Auto</w>
+                     <w xml:id="wid_00363">Wo</w>
+                     <w xml:id="wid_00364">mist</w>
+                     <w xml:id="wid_00365">das</w>
+                     <w xml:id="wid_00366">Auto</w>
                      <pc type="ws" xml:id="id_pc_1003" join="right">?</pc>
-                     <w xml:id="wid_00367" join="right">–</w>
-                     <w xml:id="wid_00368" join="right">Hier</w>
-                     <w xml:id="wid_00369" join="right">ist</w>
-                     <w xml:id="wid_00370" join="right">es</w>
+                     <w xml:id="wid_00367">–</w>
+                     <w xml:id="wid_00368">Hier</w>
+                     <w xml:id="wid_00369">ist</w>
+                     <w xml:id="wid_00370">es</w>
                      <pc type="ws" xml:id="id_pc_1012">.</pc>
                   </quote>
                </cit>
@@ -633,22 +633,22 @@
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00371" join="right">ǝḥna</w>
-                        <w ana="semlib:here" xml:id="wid_00372" join="right">hnāya</w>
-                     <w xml:id="wid_00373" join="right">mǝn</w>
-                     <w xml:id="wid_00374" join="right">ǝṯman</w>
-                     <w xml:id="wid_00375" join="right">sanawāt</w>
+                     <w xml:id="wid_00371">ǝḥna</w>
+                        <w ana="semlib:here" xml:id="wid_00372">hnāya</w>
+                     <w xml:id="wid_00373">mǝn</w>
+                     <w xml:id="wid_00374">ǝṯman</w>
+                     <w xml:id="wid_00375">sanawāt</w>
                      <pc type="ws" xml:id="id_pc_1039">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00376" join="right">Wir</w>
-                     <w xml:id="wid_00377" join="right">sind</w>
-                     <w xml:id="wid_00378" join="right">seit</w>
-                     <w xml:id="wid_00379" join="right">8</w>
-                     <w xml:id="wid_00380" join="right">Jahren</w>
-                     <w xml:id="wid_00381" join="right">hier</w>
+                     <w xml:id="wid_00376">Wir</w>
+                     <w xml:id="wid_00377">sind</w>
+                     <w xml:id="wid_00378">seit</w>
+                     <w xml:id="wid_00379">8</w>
+                     <w xml:id="wid_00380">Jahren</w>
+                     <w xml:id="wid_00381">hier</w>
                      <pc type="ws" xml:id="id_pc_1052">.</pc>
                   </quote>
                </cit>
@@ -658,36 +658,36 @@
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00387" join="right">Fāṭma</w>
+                     <w xml:id="wid_00387">Fāṭma</w>
                      <pc type="ws" xml:id="id_pc_1071" join="right">,</pc>
-                     <w xml:id="wid_00388" join="right">ǝš</w>
+                     <w xml:id="wid_00388">ǝš</w>
                      <pc type="ws" xml:id="id_pc_1074" join="right">-</pc>
-                     <w xml:id="wid_00389" join="right">da</w>
+                     <w xml:id="wid_00389">da</w>
                      <pc type="ws" xml:id="id_pc_1076" join="right">-</pc>
-                     <w xml:id="wid_00390" join="right">ssawwīn</w>
-                        <w ana="semlib:now" xml:id="wid_00391" join="right">hassa</w>
+                     <w xml:id="wid_00390">ssawwīn</w>
+                        <w ana="semlib:now" xml:id="wid_00391">hassa</w>
                      <pc type="ws" xml:id="id_pc_1080" join="right">?</pc>
-                     <w xml:id="wid_00392" join="right">–</w>
-                     <w xml:id="wid_00393" join="right">ʔašūf</w>
-                     <w xml:id="wid_00394" join="right">ǝt</w>
+                     <w xml:id="wid_00392">–</w>
+                     <w xml:id="wid_00393">ʔašūf</w>
+                     <w xml:id="wid_00394">ǝt</w>
                      <pc type="ws" xml:id="id_pc_1087" join="right">-</pc>
-                     <w xml:id="wid_00395" join="right">talfizyōn</w>
+                     <w xml:id="wid_00395">talfizyōn</w>
                      <pc type="ws" xml:id="id_pc_1089">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00396" join="right">Fatima</w>
+                     <w xml:id="wid_00396">Fatima</w>
                      <pc type="ws" xml:id="id_pc_1092" join="right">,</pc>
-                     <w xml:id="wid_00397" join="right">was</w>
-                     <w xml:id="wid_00398" join="right">machst</w>
-                     <w xml:id="wid_00399" join="right">du</w>
-                     <w xml:id="wid_00400" join="right">gerade</w>
+                     <w xml:id="wid_00397">was</w>
+                     <w xml:id="wid_00398">machst</w>
+                     <w xml:id="wid_00399">du</w>
+                     <w xml:id="wid_00400">gerade</w>
                      <pc type="ws" xml:id="id_pc_1101" join="right">?</pc>
-                     <w xml:id="wid_00401" join="right">–</w>
-                     <w xml:id="wid_00402" join="right">Ich</w>
-                     <w xml:id="wid_00403" join="right">schaue</w>
-                     <w xml:id="wid_00404" join="right">fern</w>
+                     <w xml:id="wid_00401">–</w>
+                     <w xml:id="wid_00402">Ich</w>
+                     <w xml:id="wid_00403">schaue</w>
+                     <w xml:id="wid_00404">fern</w>
                      <pc type="ws" xml:id="id_pc_1110">.</pc>
                   </quote>
                </cit>
@@ -697,26 +697,26 @@
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00412" join="right">ǝǧ</w>
+                     <w xml:id="wid_00412">ǝǧ</w>
                      <pc type="ws" xml:id="id_pc_1134" join="right">-</pc>
-                     <w xml:id="wid_00413" join="right">ǧaww</w>
+                     <w xml:id="wid_00413">ǧaww</w>
                      <phr ana="semlib:today">
-                        <w xml:id="wid_00414" join="right">ǝl</w>
+                        <w xml:id="wid_00414">ǝl</w>
                         <pc type="ws" xml:id="id_pc_1138" join="right">-</pc>
                         <w xml:id="wid_00415">yōm</w>
                         </phr>
-                     <w xml:id="wid_00416" join="right">kulliš</w>
-                     <w xml:id="wid_00417" join="right">ḥārr</w>
+                     <w xml:id="wid_00416">kulliš</w>
+                     <w xml:id="wid_00417">ḥārr</w>
                      <pc type="ws" xml:id="id_pc_1144">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00418" join="right">Heute</w>
-                     <w xml:id="wid_00419" join="right">ist</w>
-                     <w xml:id="wid_00420" join="right">es</w>
-                     <w xml:id="wid_00421" join="right">sehr</w>
-                     <w xml:id="wid_00422" join="right">heiß</w>
+                     <w xml:id="wid_00418">Heute</w>
+                     <w xml:id="wid_00419">ist</w>
+                     <w xml:id="wid_00420">es</w>
+                     <w xml:id="wid_00421">sehr</w>
+                     <w xml:id="wid_00422">heiß</w>
                      <pc type="ws" xml:id="id_pc_1155">.</pc>
                   </quote>
                </cit>
@@ -727,24 +727,24 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <phr ana="semlib:yesterday">
-                        <w xml:id="wid_00427" join="right">ǝl</w>
+                        <w xml:id="wid_00427">ǝl</w>
                         <pc type="ws" xml:id="id_pc_1173" join="right">-</pc>
                         <w xml:id="wid_00428">bārḥa</w>
                         </phr>
-                     <w xml:id="wid_00429" join="right">čānat</w>
-                     <w xml:id="wid_00430" join="right">ǝtmaṭṭǝr</w>
-                     <w xml:id="wid_00431" join="right">/</w>
-                     <w xml:id="wid_00432" join="right">tumṭur</w>
-                     <w xml:id="wid_00433" join="right">/</w>
-                     <w xml:id="wid_00434" join="right">muṭrat</w>
+                     <w xml:id="wid_00429">čānat</w>
+                     <w xml:id="wid_00430">ǝtmaṭṭǝr</w>
+                     <w xml:id="wid_00431">/</w>
+                     <w xml:id="wid_00432">tumṭur</w>
+                     <w xml:id="wid_00433">/</w>
+                     <w xml:id="wid_00434">muṭrat</w>
                      <pc type="ws" xml:id="id_pc_1187">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00435" join="right">Gestern</w>
-                     <w xml:id="wid_00436" join="right">regnete</w>
-                     <w xml:id="wid_00437" join="right">es</w>
+                     <w xml:id="wid_00435">Gestern</w>
+                     <w xml:id="wid_00436">regnete</w>
+                     <w xml:id="wid_00437">es</w>
                      <pc type="ws" xml:id="id_pc_1194">.</pc>
                   </quote>
                </cit>
@@ -754,23 +754,23 @@
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00442" join="right">ya</w>
-                     <w xml:id="wid_00443" join="right">šabāb</w>
+                     <w xml:id="wid_00442">ya</w>
+                     <w xml:id="wid_00443">šabāb</w>
                      <pc type="ws" xml:id="id_pc_1213" join="right">,</pc>
-                        <w ana="semlib:tomorrow" xml:id="wid_00444" join="right">bāčǝr</w>
-                     <w xml:id="wid_00445" join="right">lāzim</w>
-                     <w xml:id="wid_00446" join="right">ǝddursūn</w>
+                        <w ana="semlib:tomorrow" xml:id="wid_00444">bāčǝr</w>
+                     <w xml:id="wid_00445">lāzim</w>
+                     <w xml:id="wid_00446">ǝddursūn</w>
                      <pc type="ws" xml:id="id_pc_1220">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00447" join="right">Kinder</w>
+                     <w xml:id="wid_00447">Kinder</w>
                      <pc type="ws" xml:id="id_pc_1223" join="right">,</pc>
-                     <w xml:id="wid_00448" join="right">morgen</w>
-                     <w xml:id="wid_00449" join="right">müßt</w>
-                     <w xml:id="wid_00450" join="right">ihr</w>
-                     <w xml:id="wid_00451" join="right">lernen</w>
+                     <w xml:id="wid_00448">morgen</w>
+                     <w xml:id="wid_00449">müßt</w>
+                     <w xml:id="wid_00450">ihr</w>
+                     <w xml:id="wid_00451">lernen</w>
                      <pc type="ws" xml:id="id_pc_1232">.</pc>
                   </quote>
                </cit>
@@ -781,37 +781,37 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <phr ana="semlib:last_year">
-                        <w xml:id="wid_00458" join="right">s</w>
+                        <w xml:id="wid_00458">s</w>
                         <pc type="ws" xml:id="id_pc_1255" join="right">-</pc>
-                        <w xml:id="wid_00459" join="right">sana</w>
+                        <w xml:id="wid_00459">sana</w>
                         
-                        <w xml:id="wid_00460" join="right">lli</w>
+                        <w xml:id="wid_00460">lli</w>
                         
                         <w xml:id="wid_00461">rāḥat</w>
                         </phr>
-                     <w xml:id="wid_00462" join="right">/</w>
-                        <w xml:id="wid_00463" join="right">s</w>
+                     <w xml:id="wid_00462">/</w>
+                        <w xml:id="wid_00463">s</w>
                         <pc type="ws" xml:id="id_pc_1265" join="right">-</pc>
-                        <w xml:id="wid_00464" join="right">sana</w>
+                        <w xml:id="wid_00464">sana</w>
                         
-                        <w xml:id="wid_00465" join="right">l</w>
+                        <w xml:id="wid_00465">l</w>
                         <pc type="ws" xml:id="id_pc_1269" join="right">-</pc>
-                        <w xml:id="wid_00466" join="right">māð̣ya</w>
-                     <w xml:id="wid_00467" join="right">čān</w>
-                     <w xml:id="wid_00468" join="right">ʕǝdna</w>
-                     <w xml:id="wid_00469" join="right">mašākil</w>
-                     <w xml:id="wid_00470" join="right">ǝhwāya</w>
+                        <w xml:id="wid_00466">māð̣ya</w>
+                     <w xml:id="wid_00467">čān</w>
+                     <w xml:id="wid_00468">ʕǝdna</w>
+                     <w xml:id="wid_00469">mašākil</w>
+                     <w xml:id="wid_00470">ǝhwāya</w>
                      <pc type="ws" xml:id="id_pc_1279">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00471" join="right">Letztes</w>
-                     <w xml:id="wid_00472" join="right">Jahr</w>
-                     <w xml:id="wid_00473" join="right">hatten</w>
-                     <w xml:id="wid_00474" join="right">wir</w>
-                     <w xml:id="wid_00475" join="right">viele</w>
-                     <w xml:id="wid_00476" join="right">Probleme</w>
+                     <w xml:id="wid_00471">Letztes</w>
+                     <w xml:id="wid_00472">Jahr</w>
+                     <w xml:id="wid_00473">hatten</w>
+                     <w xml:id="wid_00474">wir</w>
+                     <w xml:id="wid_00475">viele</w>
+                     <w xml:id="wid_00476">Probleme</w>
                      <pc type="ws" xml:id="id_pc_1292">.</pc>
                   </quote>
                </cit>
@@ -824,22 +824,22 @@
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00483" join="right">ǝḥna</w>
-                     <w xml:id="wid_00484" join="right">hnāya</w>
-                     <w xml:id="wid_00485" join="right">mǝn</w>
-                        <w ana="semlib:eight" xml:id="wid_00486" join="right">ǝṯman</w>
-                     <w xml:id="wid_00487" join="right">sanawāt</w>
+                     <w xml:id="wid_00483">ǝḥna</w>
+                     <w xml:id="wid_00484">hnāya</w>
+                     <w xml:id="wid_00485">mǝn</w>
+                        <w ana="semlib:eight" xml:id="wid_00486">ǝṯman</w>
+                     <w xml:id="wid_00487">sanawāt</w>
                      <pc type="ws" xml:id="id_pc_1331">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00488" join="right">Wir</w>
-                     <w xml:id="wid_00489" join="right">sind</w>
-                     <w xml:id="wid_00490" join="right">seit</w>
-                     <w xml:id="wid_00491" join="right">8</w>
-                     <w xml:id="wid_00492" join="right">Jahren</w>
-                     <w xml:id="wid_00493" join="right">hier</w>
+                     <w xml:id="wid_00488">Wir</w>
+                     <w xml:id="wid_00489">sind</w>
+                     <w xml:id="wid_00490">seit</w>
+                     <w xml:id="wid_00491">8</w>
+                     <w xml:id="wid_00492">Jahren</w>
+                     <w xml:id="wid_00493">hier</w>
                      <pc type="ws" xml:id="id_pc_1344">.</pc>
                   </quote>
                </cit>
@@ -849,33 +849,33 @@
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00499" join="right">ǝšgadd</w>
-                     <w xml:id="wid_00500" join="right">/</w>
-                     <w xml:id="wid_00501" join="right">bēš</w>
-                     <w xml:id="wid_00502" join="right">ǝs</w>
+                     <w xml:id="wid_00499">ǝšgadd</w>
+                     <w xml:id="wid_00500">/</w>
+                     <w xml:id="wid_00501">bēš</w>
+                     <w xml:id="wid_00502">ǝs</w>
                      <pc type="ws" xml:id="id_pc_1369" join="right">-</pc>
-                     <w xml:id="wid_00503" join="right">sāʕa</w>
+                     <w xml:id="wid_00503">sāʕa</w>
                      <pc type="ws" xml:id="id_pc_1371" join="right">?</pc>
-                     <w xml:id="wid_00504" join="right">–</w>
-                     <w xml:id="wid_00505" join="right">ǝs</w>
+                     <w xml:id="wid_00504">–</w>
+                     <w xml:id="wid_00505">ǝs</w>
                      <pc type="ws" xml:id="id_pc_1376" join="right">-</pc>
-                     <w xml:id="wid_00506" join="right">sāʕa</w>
-                        <w ana="semlib:eleven" xml:id="wid_00507" join="right">daʕaš</w>
+                     <w xml:id="wid_00506">sāʕa</w>
+                        <w ana="semlib:eleven" xml:id="wid_00507">daʕaš</w>
                      <pc type="ws" xml:id="id_pc_1380">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00508" join="right">Wie</w>
-                     <w xml:id="wid_00509" join="right">spät</w>
-                     <w xml:id="wid_00510" join="right">ist</w>
-                     <w xml:id="wid_00511" join="right">es</w>
+                     <w xml:id="wid_00508">Wie</w>
+                     <w xml:id="wid_00509">spät</w>
+                     <w xml:id="wid_00510">ist</w>
+                     <w xml:id="wid_00511">es</w>
                      <pc type="ws" xml:id="id_pc_1389" join="right">?</pc>
-                     <w xml:id="wid_00512" join="right">–</w>
-                     <w xml:id="wid_00513" join="right">Es</w>
-                     <w xml:id="wid_00514" join="right">ist</w>
-                     <w xml:id="wid_00515" join="right">11</w>
-                     <w xml:id="wid_00516" join="right">Uhr</w>
+                     <w xml:id="wid_00512">–</w>
+                     <w xml:id="wid_00513">Es</w>
+                     <w xml:id="wid_00514">ist</w>
+                     <w xml:id="wid_00515">11</w>
+                     <w xml:id="wid_00516">Uhr</w>
                      <pc type="ws" xml:id="id_pc_1400">.</pc>
                   </quote>
                </cit>
@@ -885,26 +885,26 @@
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00521" join="right">ʕǝdhum</w>
-                        <w ana="semlib:twelve" xml:id="wid_00522" join="right">ǝṯnaʕaš</w>
-                     <w xml:id="wid_00523" join="right">ṣaxla</w>
-                     <w xml:id="wid_00524" join="right">/</w>
-                     <w xml:id="wid_00525" join="right">maʕza</w>
-                     <w xml:id="wid_00526" join="right">wǝ</w>
+                     <w xml:id="wid_00521">ʕǝdhum</w>
+                        <w ana="semlib:twelve" xml:id="wid_00522">ǝṯnaʕaš</w>
+                     <w xml:id="wid_00523">ṣaxla</w>
+                     <w xml:id="wid_00524">/</w>
+                     <w xml:id="wid_00525">maʕza</w>
+                     <w xml:id="wid_00526">wǝ</w>
                      <pc type="ws" xml:id="id_pc_1427" join="right">-</pc>
-                     <w xml:id="wid_00527" join="right">baqartēn</w>
+                     <w xml:id="wid_00527">baqartēn</w>
                      <pc type="ws" xml:id="id_pc_1429">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00528" join="right">Sie</w>
-                     <w xml:id="wid_00529" join="right">haben</w>
-                     <w xml:id="wid_00530" join="right">12</w>
-                     <w xml:id="wid_00531" join="right">Ziegen</w>
-                     <w xml:id="wid_00532" join="right">und</w>
-                     <w xml:id="wid_00533" join="right">2</w>
-                     <w xml:id="wid_00534" join="right">Kühe</w>
+                     <w xml:id="wid_00528">Sie</w>
+                     <w xml:id="wid_00529">haben</w>
+                     <w xml:id="wid_00530">12</w>
+                     <w xml:id="wid_00531">Ziegen</w>
+                     <w xml:id="wid_00532">und</w>
+                     <w xml:id="wid_00533">2</w>
+                     <w xml:id="wid_00534">Kühe</w>
                      <pc type="ws" xml:id="id_pc_1444">.</pc>
                   </quote>
                </cit>
@@ -914,24 +914,24 @@
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00539" join="right">ǝb</w>
+                     <w xml:id="wid_00539">ǝb</w>
                      <pc type="ws" xml:id="id_pc_1461" join="right">-</pc>
-                     <w xml:id="wid_00540" join="right">ṣaffna</w>
-                        <w ana="semlib:eighteen" xml:id="wid_00541" join="right">ṯmunṭaʕaš</w>
-                     <w xml:id="wid_00542" join="right">ṭālib</w>
-                     <w xml:id="wid_00543" join="right">ǝǧdīd</w>
+                     <w xml:id="wid_00540">ṣaffna</w>
+                        <w ana="semlib:eighteen" xml:id="wid_00541">ṯmunṭaʕaš</w>
+                     <w xml:id="wid_00542">ṭālib</w>
+                     <w xml:id="wid_00543">ǝǧdīd</w>
                      <pc type="ws" xml:id="id_pc_1469">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00544" join="right">In</w>
-                     <w xml:id="wid_00545" join="right">unserer</w>
-                     <w xml:id="wid_00546" join="right">Klasse</w>
-                     <w xml:id="wid_00547" join="right">sind</w>
-                     <w xml:id="wid_00548" join="right">18</w>
-                     <w xml:id="wid_00549" join="right">neue</w>
-                     <w xml:id="wid_00550" join="right">Studenten</w>
+                     <w xml:id="wid_00544">In</w>
+                     <w xml:id="wid_00545">unserer</w>
+                     <w xml:id="wid_00546">Klasse</w>
+                     <w xml:id="wid_00547">sind</w>
+                     <w xml:id="wid_00548">18</w>
+                     <w xml:id="wid_00549">neue</w>
+                     <w xml:id="wid_00550">Studenten</w>
                      <pc type="ws" xml:id="id_pc_1484">.</pc>
                   </quote>
                </cit>
@@ -944,36 +944,36 @@
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00556" join="right">ǝšlōnak</w>
-                     <w xml:id="wid_00557" join="right">/</w>
-                     <w xml:id="wid_00558" join="right">ǝšlōnǝč</w>
+                     <w xml:id="wid_00556">ǝšlōnak</w>
+                     <w xml:id="wid_00557">/</w>
+                     <w xml:id="wid_00558">ǝšlōnǝč</w>
                      <pc type="ws" xml:id="id_pc_1517" join="right">?</pc>
-                     <w xml:id="wid_00559" join="right">–</w>
-                        <w ana="semlib:good" xml:id="wid_00560" join="right">zēn</w>
-                     <w xml:id="wid_00561" join="right">/</w>
-                        <w xml:id="wid_00562" join="right">zēna</w>
+                     <w xml:id="wid_00559">–</w>
+                        <w ana="semlib:good" xml:id="wid_00560">zēn</w>
+                     <w xml:id="wid_00561">/</w>
+                        <w xml:id="wid_00562">zēna</w>
                      <pc type="ws" xml:id="id_pc_1526" join="right">,</pc>
-                     <w xml:id="wid_00563" join="right">l</w>
+                     <w xml:id="wid_00563">l</w>
                      <pc type="ws" xml:id="id_pc_1529" join="right">-</pc>
-                     <w xml:id="wid_00564" join="right">ḥamdilla</w>
+                     <w xml:id="wid_00564">ḥamdilla</w>
                      <pc type="ws" xml:id="id_pc_1531">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00565" join="right">Wie</w>
-                     <w xml:id="wid_00566" join="right">geht</w>
-                     <w xml:id="wid_00567" join="right">es</w>
-                     <w xml:id="wid_00568" join="right">dir</w>
+                     <w xml:id="wid_00565">Wie</w>
+                     <w xml:id="wid_00566">geht</w>
+                     <w xml:id="wid_00567">es</w>
+                     <w xml:id="wid_00568">dir</w>
                      <pc type="ws" xml:id="id_pc_1541" join="right">(</pc>
-                     <w xml:id="wid_00569" join="right">m/f</w>
+                     <w xml:id="wid_00569">m/f</w>
                      <pc type="ws" xml:id="id_pc_1543" join="right">)</pc>
                      <pc type="ws" xml:id="id_pc_1544" join="right">?</pc>
-                     <w xml:id="wid_00570" join="right">–</w>
-                     <w xml:id="wid_00571" join="right">Mir</w>
-                     <w xml:id="wid_00572" join="right">geht</w>
-                     <w xml:id="wid_00573" join="right">es</w>
-                     <w xml:id="wid_00574" join="right">gut</w>
+                     <w xml:id="wid_00570">–</w>
+                     <w xml:id="wid_00571">Mir</w>
+                     <w xml:id="wid_00572">geht</w>
+                     <w xml:id="wid_00573">es</w>
+                     <w xml:id="wid_00574">gut</w>
                      <pc type="ws" xml:id="id_pc_1555">.</pc>
                   </quote>
                </cit>
@@ -987,33 +987,33 @@
                      car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00581" join="right">yǝlbas</w>
-                     <w xml:id="wid_00582" join="right">raǧli</w>
-                     <w ana="semlib:shirt" xml:id="wid_00583" join="right">qamīṣ</w>
-                        <w ana="semlib:white" xml:id="wid_00584" join="right">ʔabyað̣</w>
-                     <w xml:id="wid_00585" join="right">w</w>
+                     <w xml:id="wid_00581">yǝlbas</w>
+                     <w xml:id="wid_00582">raǧli</w>
+                     <w ana="semlib:shirt" xml:id="wid_00583">qamīṣ</w>
+                        <w ana="semlib:white" xml:id="wid_00584">ʔabyað̣</w>
+                     <w xml:id="wid_00585">w</w>
                      <pc type="ws" xml:id="id_pc_1595" join="right">-</pc>
-                     <w xml:id="wid_00586" join="right">ʔāni</w>
-                     <w xml:id="wid_00587" join="right">ʔalbas</w>
-                     <w xml:id="wid_00588" join="right">badla</w>
-                        <w xml:id="wid_00589" join="right">bēð̣a</w>
+                     <w xml:id="wid_00586">ʔāni</w>
+                     <w xml:id="wid_00587">ʔalbas</w>
+                     <w xml:id="wid_00588">badla</w>
+                        <w xml:id="wid_00589">bēð̣a</w>
                      <pc type="ws" xml:id="id_pc_1603">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00590" join="right">Mein</w>
-                     <w xml:id="wid_00591" join="right">Mann</w>
-                     <w xml:id="wid_00592" join="right">trägt</w>
-                     <w xml:id="wid_00593" join="right">ein</w>
-                     <w xml:id="wid_00594" join="right">weißes</w>
-                     <w xml:id="wid_00595" join="right">Hemd</w>
-                     <w xml:id="wid_00596" join="right">und</w>
-                     <w xml:id="wid_00597" join="right">ich</w>
-                     <w xml:id="wid_00598" join="right">trage</w>
-                     <w xml:id="wid_00599" join="right">ein</w>
-                     <w xml:id="wid_00600" join="right">weißes</w>
-                     <w xml:id="wid_00601" join="right">Kleid</w>
+                     <w xml:id="wid_00590">Mein</w>
+                     <w xml:id="wid_00591">Mann</w>
+                     <w xml:id="wid_00592">trägt</w>
+                     <w xml:id="wid_00593">ein</w>
+                     <w xml:id="wid_00594">weißes</w>
+                     <w xml:id="wid_00595">Hemd</w>
+                     <w xml:id="wid_00596">und</w>
+                     <w xml:id="wid_00597">ich</w>
+                     <w xml:id="wid_00598">trage</w>
+                     <w xml:id="wid_00599">ein</w>
+                     <w xml:id="wid_00600">weißes</w>
+                     <w xml:id="wid_00601">Kleid</w>
                      <pc type="ws" xml:id="id_pc_1628">.</pc>
                   </quote>
                </cit>
@@ -1023,37 +1023,37 @@
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00610" join="right">ma</w>
-                     <w xml:id="wid_00611" join="right">yǝʕǧibni</w>
-                     <w xml:id="wid_00612" join="right">hāḏa</w>
-                     <w xml:id="wid_00613" join="right">l</w>
+                     <w xml:id="wid_00610">ma</w>
+                     <w xml:id="wid_00611">yǝʕǧibni</w>
+                     <w xml:id="wid_00612">hāḏa</w>
+                     <w xml:id="wid_00613">l</w>
                      <pc type="ws" xml:id="id_pc_1659" join="right">-</pc>
-                     <w xml:id="wid_00614" join="right">qamīṣ</w>
-                     <w xml:id="wid_00615" join="right">ǝl</w>
+                     <w xml:id="wid_00614">qamīṣ</w>
+                     <w xml:id="wid_00615">ǝl</w>
                      <pc type="ws" xml:id="id_pc_1663" join="right">-</pc>
-                        <w ana="semlib:black" xml:id="wid_00616" join="right">ʔaswad</w>
+                        <w ana="semlib:black" xml:id="wid_00616">ʔaswad</w>
                      <pc type="ws" xml:id="id_pc_1665" join="right">.</pc>
-                     <w xml:id="wid_00617" join="right">/</w>
-                     <w xml:id="wid_00618" join="right">ma</w>
-                     <w xml:id="wid_00619" join="right">tǝʕǧibni</w>
-                     <w xml:id="wid_00620" join="right">hāḏi</w>
-                     <w xml:id="wid_00621" join="right">s</w>
+                     <w xml:id="wid_00617">/</w>
+                     <w xml:id="wid_00618">ma</w>
+                     <w xml:id="wid_00619">tǝʕǧibni</w>
+                     <w xml:id="wid_00620">hāḏi</w>
+                     <w xml:id="wid_00621">s</w>
                      <pc type="ws" xml:id="id_pc_1676" join="right">-</pc>
-                     <w xml:id="wid_00622" join="right">siyyāra</w>
-                     <w xml:id="wid_00623" join="right">s</w>
+                     <w xml:id="wid_00622">siyyāra</w>
+                     <w xml:id="wid_00623">s</w>
                      <pc type="ws" xml:id="id_pc_1680" join="right">-</pc>
-                        <w xml:id="wid_00624" join="right">sōda</w>
+                        <w xml:id="wid_00624">sōda</w>
                      <pc type="ws" xml:id="id_pc_1682">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00625" join="right">Dieses</w>
-                     <w xml:id="wid_00626" join="right">schwarze</w>
-                     <w xml:id="wid_00627" join="right">Hemd/Auto</w>
-                     <w xml:id="wid_00628" join="right">gefällt</w>
-                     <w xml:id="wid_00629" join="right">mir</w>
-                     <w xml:id="wid_00630" join="right">nicht</w>
+                     <w xml:id="wid_00625">Dieses</w>
+                     <w xml:id="wid_00626">schwarze</w>
+                     <w xml:id="wid_00627">Hemd/Auto</w>
+                     <w xml:id="wid_00628">gefällt</w>
+                     <w xml:id="wid_00629">mir</w>
+                     <w xml:id="wid_00630">nicht</w>
                      <pc type="ws" xml:id="id_pc_1695">.</pc>
                   </quote>
                </cit>
@@ -1063,28 +1063,28 @@
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00641" join="right">ǝštarat</w>
-                     <w xml:id="wid_00642" join="right">marti</w>
-                     <w xml:id="wid_00643" join="right">qamīṣ</w>
-                        <w ana="semlib:pink" xml:id="wid_00644" join="right">wardi</w>
-                     <w xml:id="wid_00645" join="right">w</w>
+                     <w xml:id="wid_00641">ǝštarat</w>
+                     <w xml:id="wid_00642">marti</w>
+                     <w xml:id="wid_00643">qamīṣ</w>
+                        <w ana="semlib:pink" xml:id="wid_00644">wardi</w>
+                     <w xml:id="wid_00645">w</w>
                      <pc type="ws" xml:id="id_pc_1732" join="right">-</pc>
-                     <w xml:id="wid_00646" join="right">ǧunṭa</w>
-                        <w xml:id="wid_00647" join="right">wardīya</w>
+                     <w xml:id="wid_00646">ǧunṭa</w>
+                        <w xml:id="wid_00647">wardīya</w>
                      <pc type="ws" xml:id="id_pc_1736">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00648" join="right">Meine</w>
-                     <w xml:id="wid_00649" join="right">Frau</w>
-                     <w xml:id="wid_00650" join="right">hat</w>
-                     <w xml:id="wid_00651" join="right">ein</w>
-                     <w xml:id="wid_00652" join="right">rosa</w>
-                     <w xml:id="wid_00653" join="right">Hemd/eine</w>
-                     <w xml:id="wid_00654" join="right">rosa</w>
-                     <w xml:id="wid_00655" join="right">Tasche</w>
-                     <w xml:id="wid_00656" join="right">gekauft</w>
+                     <w xml:id="wid_00648">Meine</w>
+                     <w xml:id="wid_00649">Frau</w>
+                     <w xml:id="wid_00650">hat</w>
+                     <w xml:id="wid_00651">ein</w>
+                     <w xml:id="wid_00652">rosa</w>
+                     <w xml:id="wid_00653">Hemd/eine</w>
+                     <w xml:id="wid_00654">rosa</w>
+                     <w xml:id="wid_00655">Tasche</w>
+                     <w xml:id="wid_00656">gekauft</w>
                      <pc type="ws" xml:id="id_pc_1755">.</pc>
                   </quote>
                </cit>
@@ -1094,24 +1094,24 @@
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00663" join="right">ḥāyǝṭ</w>
-                        <w ana="semlib:grey" xml:id="wid_00664" join="right">rumādi</w>
+                     <w xml:id="wid_00663">ḥāyǝṭ</w>
+                        <w ana="semlib:grey" xml:id="wid_00664">rumādi</w>
                      <pc type="ws" xml:id="id_pc_1779" join="right">(</pc>
-                        <w xml:id="wid_00665" join="right">riṣāṣi</w>
+                        <w xml:id="wid_00665">riṣāṣi</w>
                      <pc type="ws" xml:id="id_pc_1781" join="right">)</pc>
-                     <w xml:id="wid_00666" join="right">/</w>
-                     <w xml:id="wid_00667" join="right">ǧunṭa</w>
-                        <w xml:id="wid_00668" join="right">rumādīya</w>
+                     <w xml:id="wid_00666">/</w>
+                     <w xml:id="wid_00667">ǧunṭa</w>
+                        <w xml:id="wid_00668">rumādīya</w>
                      <pc type="ws" xml:id="id_pc_1789" join="right">(</pc>
-                        <w xml:id="wid_00669" join="right">riṣāṣīya</w>
+                        <w xml:id="wid_00669">riṣāṣīya</w>
                      <pc type="ws" xml:id="id_pc_1791">)</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00670" join="right">eine</w>
-                     <w xml:id="wid_00671" join="right">graue</w>
-                     <w xml:id="wid_00672" join="right">Mauer/graue</w>
+                     <w xml:id="wid_00670">eine</w>
+                     <w xml:id="wid_00671">graue</w>
+                     <w xml:id="wid_00672">Mauer/graue</w>
                      <w xml:id="wid_00673">Tasche</w>
                   </quote>
                </cit>
@@ -1121,17 +1121,17 @@
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00678" join="right">qamīṣ</w>
-                        <w ana="semlib:orange" xml:id="wid_00679" join="right">burtuqāli</w>
-                     <w xml:id="wid_00680" join="right">/</w>
-                     <w xml:id="wid_00681" join="right">siyyāra</w>
+                     <w xml:id="wid_00678">qamīṣ</w>
+                        <w ana="semlib:orange" xml:id="wid_00679">burtuqāli</w>
+                     <w xml:id="wid_00680">/</w>
+                     <w xml:id="wid_00681">siyyāra</w>
                         <w xml:id="wid_00682">burtuqālīya</w>
                      </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00683" join="right">ein</w>
-                     <w xml:id="wid_00684" join="right">oranges</w>
+                     <w xml:id="wid_00683">ein</w>
+                     <w xml:id="wid_00684">oranges</w>
                      <w xml:id="wid_00685">Hemd/Auto</w>
                   </quote>
                </cit>
@@ -1146,24 +1146,24 @@
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w ana="semlib:in" xml:id="wid_00691" join="right">ǝb</w>
+                     <w ana="semlib:in" xml:id="wid_00691">ǝb</w>
                      <pc type="ws" xml:id="id_pc_1859" join="right">-</pc>
-                     <w xml:id="wid_00692" join="right">ṣaffna</w>
-                        <w xml:id="wid_00693" join="right">ṯmunṭaʕaš</w>
-                     <w xml:id="wid_00694" join="right">ṭālib</w>
-                     <w xml:id="wid_00695" join="right">ǝǧdīd</w>
+                     <w xml:id="wid_00692">ṣaffna</w>
+                        <w xml:id="wid_00693">ṯmunṭaʕaš</w>
+                     <w xml:id="wid_00694">ṭālib</w>
+                     <w xml:id="wid_00695">ǝǧdīd</w>
                      <pc type="ws" xml:id="id_pc_1867">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00696" join="right">In</w>
-                     <w xml:id="wid_00697" join="right">unserer</w>
-                     <w xml:id="wid_00698" join="right">Klasse</w>
-                     <w xml:id="wid_00699" join="right">sind</w>
-                     <w xml:id="wid_00700" join="right">18</w>
-                     <w xml:id="wid_00701" join="right">neue</w>
-                     <w xml:id="wid_00702" join="right">Studenten</w>
+                     <w xml:id="wid_00696">In</w>
+                     <w xml:id="wid_00697">unserer</w>
+                     <w xml:id="wid_00698">Klasse</w>
+                     <w xml:id="wid_00699">sind</w>
+                     <w xml:id="wid_00700">18</w>
+                     <w xml:id="wid_00701">neue</w>
+                     <w xml:id="wid_00702">Studenten</w>
                      <pc type="ws" xml:id="id_pc_1882">.</pc>
                   </quote>
                </cit>
@@ -1176,38 +1176,38 @@
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00708" join="right">Fāṭma</w>
+                     <w xml:id="wid_00708">Fāṭma</w>
                      <pc type="ws" xml:id="id_pc_1911" join="right">,</pc>
-                     <w xml:id="wid_00709" join="right">ǝš</w>
+                     <w xml:id="wid_00709">ǝš</w>
                      <pc type="ws" xml:id="id_pc_1914" join="right">-</pc>
                      <phr ana="semlib:to_do">
-                        <w xml:id="wid_00710" join="right">da</w>
+                        <w xml:id="wid_00710">da</w>
                         <pc type="ws" xml:id="id_pc_1916" join="right">-</pc>
                         <w xml:id="wid_00711">ssawwīn</w>
                         </phr>
-                     <w xml:id="wid_00712" join="right">hassa</w>
+                     <w xml:id="wid_00712">hassa</w>
                      <pc type="ws" xml:id="id_pc_1920" join="right">?</pc>
-                     <w xml:id="wid_00713" join="right">–</w>
-                     <w xml:id="wid_00714" join="right">ʔašūf</w>
-                     <w xml:id="wid_00715" join="right">ǝt</w>
+                     <w xml:id="wid_00713">–</w>
+                     <w xml:id="wid_00714">ʔašūf</w>
+                     <w xml:id="wid_00715">ǝt</w>
                      <pc type="ws" xml:id="id_pc_1927" join="right">-</pc>
-                     <w xml:id="wid_00716" join="right">talfizyōn</w>
+                     <w xml:id="wid_00716">talfizyōn</w>
                      <pc type="ws" xml:id="id_pc_1929">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00717" join="right">Fatima</w>
+                     <w xml:id="wid_00717">Fatima</w>
                      <pc type="ws" xml:id="id_pc_1932" join="right">,</pc>
-                     <w xml:id="wid_00718" join="right">was</w>
-                     <w xml:id="wid_00719" join="right">machst</w>
-                     <w xml:id="wid_00720" join="right">du</w>
-                     <w xml:id="wid_00721" join="right">gerade</w>
+                     <w xml:id="wid_00718">was</w>
+                     <w xml:id="wid_00719">machst</w>
+                     <w xml:id="wid_00720">du</w>
+                     <w xml:id="wid_00721">gerade</w>
                      <pc type="ws" xml:id="id_pc_1941" join="right">?</pc>
-                     <w xml:id="wid_00722" join="right">–</w>
-                     <w xml:id="wid_00723" join="right">Ich</w>
-                     <w xml:id="wid_00724" join="right">schaue</w>
-                     <w xml:id="wid_00725" join="right">fern</w>
+                     <w xml:id="wid_00722">–</w>
+                     <w xml:id="wid_00723">Ich</w>
+                     <w xml:id="wid_00724">schaue</w>
+                     <w xml:id="wid_00725">fern</w>
                      <pc type="ws" xml:id="id_pc_1950">.</pc>
                   </quote>
                </cit>
@@ -1217,47 +1217,47 @@
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_stay" xml:id="wid_00733" join="right">ubqa</w>
+                        <w ana="semlib:to_stay" xml:id="wid_00733">ubqa</w>
                      <pc type="ws" xml:id="id_pc_1976" join="right">(</pc>
-                     <w xml:id="wid_00734" join="right">m</w>
+                     <w xml:id="wid_00734">m</w>
                      <pc type="ws" xml:id="id_pc_1978" join="right">.</pc>
                      <pc type="ws" xml:id="id_pc_1979" join="right">)</pc>
-                     <w xml:id="wid_00735" join="right">/</w>
-                        <w xml:id="wid_00736" join="right">ubqi</w>
+                     <w xml:id="wid_00735">/</w>
+                        <w xml:id="wid_00736">ubqi</w>
                      <pc type="ws" xml:id="id_pc_1985" join="right">(</pc>
-                     <w xml:id="wid_00737" join="right">f</w>
+                     <w xml:id="wid_00737">f</w>
                      <pc type="ws" xml:id="id_pc_1987" join="right">.</pc>
                      <pc type="ws" xml:id="id_pc_1988" join="right">)</pc>
-                     <w xml:id="wid_00738" join="right">/</w>
-                        <w xml:id="wid_00739" join="right">ubqu</w>
+                     <w xml:id="wid_00738">/</w>
+                        <w xml:id="wid_00739">ubqu</w>
                      <pc type="ws" xml:id="id_pc_1994" join="right">(</pc>
-                     <w xml:id="wid_00740" join="right">pl</w>
+                     <w xml:id="wid_00740">pl</w>
                      <pc type="ws" xml:id="id_pc_1996" join="right">.</pc>
                      <pc type="ws" xml:id="id_pc_1997" join="right">)</pc>
-                     <w xml:id="wid_00741" join="right">hnāya</w>
-                     <w xml:id="wid_00742" join="right">šwayya</w>
+                     <w xml:id="wid_00741">hnāya</w>
+                     <w xml:id="wid_00742">šwayya</w>
                      <pc type="ws" xml:id="id_pc_2002" join="right">!</pc>
-                     <w xml:id="wid_00743" join="right">–</w>
-                     <w xml:id="wid_00744" join="right">lā</w>
+                     <w xml:id="wid_00743">–</w>
+                     <w xml:id="wid_00744">lā</w>
                      <pc type="ws" xml:id="id_pc_2007" join="right">,</pc>
-                     <w xml:id="wid_00745" join="right">ma</w>
-                     <w xml:id="wid_00746" join="right">ʕǝddi</w>
-                     <w xml:id="wid_00747" join="right">waqit</w>
+                     <w xml:id="wid_00745">ma</w>
+                     <w xml:id="wid_00746">ʕǝddi</w>
+                     <w xml:id="wid_00747">waqit</w>
                      <pc type="ws" xml:id="id_pc_2014">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00748" join="right">Bleib</w>
-                     <w xml:id="wid_00749" join="right">ein</w>
-                     <w xml:id="wid_00750" join="right">bißchen</w>
+                     <w xml:id="wid_00748">Bleib</w>
+                     <w xml:id="wid_00749">ein</w>
+                     <w xml:id="wid_00750">bißchen</w>
                      <pc type="ws" xml:id="id_pc_2021" join="right">!</pc>
-                     <w xml:id="wid_00751" join="right">Nein</w>
+                     <w xml:id="wid_00751">Nein</w>
                      <pc type="ws" xml:id="id_pc_2024" join="right">,</pc>
-                     <w xml:id="wid_00752" join="right">ich</w>
-                     <w xml:id="wid_00753" join="right">habe</w>
-                     <w xml:id="wid_00754" join="right">keine</w>
-                     <w xml:id="wid_00755" join="right">Zeit</w>
+                     <w xml:id="wid_00752">ich</w>
+                     <w xml:id="wid_00753">habe</w>
+                     <w xml:id="wid_00754">keine</w>
+                     <w xml:id="wid_00755">Zeit</w>
                      <pc type="ws" xml:id="id_pc_2033">.</pc>
                   </quote>
                </cit>
@@ -1267,25 +1267,25 @@
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_speak" xml:id="wid_00763" join="right">tǝḥči</w>
-                     <w xml:id="wid_00764" join="right">ʕarabi</w>
+                        <w ana="semlib:to_speak" xml:id="wid_00763">tǝḥči</w>
+                     <w xml:id="wid_00764">ʕarabi</w>
                      <pc type="ws" xml:id="id_pc_2060" join="right">?</pc>
-                     <w xml:id="wid_00765" join="right">–</w>
-                     <w xml:id="wid_00766" join="right">bass</w>
-                     <w xml:id="wid_00767" join="right">ǝšwayya</w>
+                     <w xml:id="wid_00765">–</w>
+                     <w xml:id="wid_00766">bass</w>
+                     <w xml:id="wid_00767">ǝšwayya</w>
                      <pc type="ws" xml:id="id_pc_2067">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00768" join="right">Sprichst</w>
-                     <w xml:id="wid_00769" join="right">du</w>
-                     <w xml:id="wid_00770" join="right">Arabisch</w>
+                     <w xml:id="wid_00768">Sprichst</w>
+                     <w xml:id="wid_00769">du</w>
+                     <w xml:id="wid_00770">Arabisch</w>
                      <pc type="ws" xml:id="id_pc_2074" join="right">?</pc>
-                     <w xml:id="wid_00771" join="right">–</w>
-                     <w xml:id="wid_00772" join="right">Nur</w>
-                     <w xml:id="wid_00773" join="right">ein</w>
-                     <w xml:id="wid_00774" join="right">bißchen</w>
+                     <w xml:id="wid_00771">–</w>
+                     <w xml:id="wid_00772">Nur</w>
+                     <w xml:id="wid_00773">ein</w>
+                     <w xml:id="wid_00774">bißchen</w>
                      <pc type="ws" xml:id="id_pc_2083">.</pc>
                   </quote>
                </cit>
@@ -1295,26 +1295,26 @@
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00780" join="right">ǝl</w>
+                     <w xml:id="wid_00780">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2102" join="right">-</pc>
-                     <w xml:id="wid_00781" join="right">bārḥa</w>
+                     <w xml:id="wid_00781">bārḥa</w>
                      <phr ana="semlib:to_rain">
-                        <w xml:id="wid_00782" join="right">čānat</w>
+                        <w xml:id="wid_00782">čānat</w>
                         
                         <w xml:id="wid_00783">ǝtmaṭṭǝr</w>
                         </phr>
-                     <w xml:id="wid_00784" join="right">/</w>
-                        <w xml:id="wid_00785" join="right">tumṭur</w>
-                     <w xml:id="wid_00786" join="right">/</w>
-                        <w xml:id="wid_00787" join="right">muṭrat</w>
+                     <w xml:id="wid_00784">/</w>
+                        <w xml:id="wid_00785">tumṭur</w>
+                     <w xml:id="wid_00786">/</w>
+                        <w xml:id="wid_00787">muṭrat</w>
                      <pc type="ws" xml:id="id_pc_2116">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00788" join="right">Gestern</w>
-                     <w xml:id="wid_00789" join="right">regnete</w>
-                     <w xml:id="wid_00790" join="right">es</w>
+                     <w xml:id="wid_00788">Gestern</w>
+                     <w xml:id="wid_00789">regnete</w>
+                     <w xml:id="wid_00790">es</w>
                      <pc type="ws" xml:id="id_pc_2123">.</pc>
                   </quote>
                </cit>
@@ -1324,19 +1324,19 @@
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_open" xml:id="wid_00791" join="right">ǝftaḥ</w>
-                     <w xml:id="wid_00792" join="right">ǝš</w>
+                        <w ana="semlib:to_open" xml:id="wid_00791">ǝftaḥ</w>
+                     <w xml:id="wid_00792">ǝš</w>
                      <pc type="ws" xml:id="id_pc_2135" join="right">-</pc>
-                     <w ana="semlib:window" xml:id="wid_00793" join="right">šubbāk</w>
+                     <w ana="semlib:window" xml:id="wid_00793">šubbāk</w>
                      <pc type="ws" xml:id="id_pc_2137">!</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00794" join="right">Mach</w>
-                     <w xml:id="wid_00795" join="right">das</w>
-                     <w xml:id="wid_00796" join="right">Fenster</w>
-                     <w xml:id="wid_00797" join="right">auf</w>
+                     <w xml:id="wid_00794">Mach</w>
+                     <w xml:id="wid_00795">das</w>
+                     <w xml:id="wid_00796">Fenster</w>
+                     <w xml:id="wid_00797">auf</w>
                      <pc type="ws" xml:id="id_pc_2146">!</pc>
                   </quote>
                </cit>
@@ -1346,18 +1346,18 @@
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_close" xml:id="wid_00800" join="right">sidd</w>
-                     <w xml:id="wid_00801" join="right">ǝl</w>
+                        <w ana="semlib:to_close" xml:id="wid_00800">sidd</w>
+                     <w xml:id="wid_00801">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2162" join="right">-</pc>
-                     <w xml:id="wid_00802" join="right">bībān</w>
+                     <w xml:id="wid_00802">bībān</w>
                      <pc type="ws" xml:id="id_pc_2164">!</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00803" join="right">Mach</w>
-                     <w xml:id="wid_00804" join="right">dieTüren</w>
-                     <w xml:id="wid_00805" join="right">zu</w>
+                     <w xml:id="wid_00803">Mach</w>
+                     <w xml:id="wid_00804">dieTüren</w>
+                     <w xml:id="wid_00805">zu</w>
                      <pc type="ws" xml:id="id_pc_2171">!</pc>
                   </quote>
                </cit>
@@ -1367,30 +1367,30 @@
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00808" join="right">šǝnu</w>
-                        <w ana="semlib:to_take" xml:id="wid_00809" join="right">ʔaxaḏti</w>
-                     <w xml:id="wid_00810" join="right">wiyyāč</w>
+                     <w xml:id="wid_00808">šǝnu</w>
+                        <w ana="semlib:to_take" xml:id="wid_00809">ʔaxaḏti</w>
+                     <w xml:id="wid_00810">wiyyāč</w>
                      <pc type="ws" xml:id="id_pc_2188" join="right">?</pc>
-                     <w xml:id="wid_00811" join="right">/</w>
-                     <w xml:id="wid_00812" join="right">šǝnu</w>
-                        <w xml:id="wid_00813" join="right">ʔaxaḏǝt</w>
-                     <w xml:id="wid_00814" join="right">wiyyāk</w>
+                     <w xml:id="wid_00811">/</w>
+                     <w xml:id="wid_00812">šǝnu</w>
+                        <w xml:id="wid_00813">ʔaxaḏǝt</w>
+                     <w xml:id="wid_00814">wiyyāk</w>
                      <pc type="ws" xml:id="id_pc_2197" join="right">?</pc>
-                     <w xml:id="wid_00815" join="right">–</w>
-                     <w xml:id="wid_00816" join="right">ma</w>
-                     <w xml:id="wid_00817" join="right">ʔaxaḏǝt</w>
-                     <w xml:id="wid_00818" join="right">šī</w>
+                     <w xml:id="wid_00815">–</w>
+                     <w xml:id="wid_00816">ma</w>
+                     <w xml:id="wid_00817">ʔaxaḏǝt</w>
+                     <w xml:id="wid_00818">šī</w>
                      <pc type="ws" xml:id="id_pc_2206">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00819" join="right">Was</w>
-                     <w xml:id="wid_00820" join="right">hast</w>
-                     <w xml:id="wid_00821" join="right">du</w>
-                     <w xml:id="wid_00822" join="right">genommen</w>
+                     <w xml:id="wid_00819">Was</w>
+                     <w xml:id="wid_00820">hast</w>
+                     <w xml:id="wid_00821">du</w>
+                     <w xml:id="wid_00822">genommen</w>
                      <pc type="ws" xml:id="id_pc_2215" join="right">?</pc>
-                     <w xml:id="wid_00823" join="right">Nichts</w>
+                     <w xml:id="wid_00823">Nichts</w>
                      <pc type="ws" xml:id="id_pc_2217">.</pc>
                   </quote>
                </cit>
@@ -1401,41 +1401,41 @@
                      him.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_give" xml:id="wid_00830" join="right">ǝnṭēt</w>
-                     <w xml:id="wid_00831" join="right">/</w>
-                        <w xml:id="wid_00832" join="right">ǝṭṭēt</w>
-                     <w xml:id="wid_00833" join="right">Aḥmad</w>
-                     <w xml:id="wid_00834" join="right">ǝr</w>
+                        <w ana="semlib:to_give" xml:id="wid_00830">ǝnṭēt</w>
+                     <w xml:id="wid_00831">/</w>
+                        <w xml:id="wid_00832">ǝṭṭēt</w>
+                     <w xml:id="wid_00833">Aḥmad</w>
+                     <w xml:id="wid_00834">ǝr</w>
                      <pc type="ws" xml:id="id_pc_2250" join="right">-</pc>
-                     <w ana="semlib:letter" xml:id="wid_00835" join="right">risāla</w>
+                     <w ana="semlib:letter" xml:id="wid_00835">risāla</w>
                      <pc type="ws" xml:id="id_pc_2252" join="right">?</pc>
-                     <w xml:id="wid_00836" join="right">–</w>
-                     <w xml:id="wid_00837" join="right">ʔē</w>
+                     <w xml:id="wid_00836">–</w>
+                     <w xml:id="wid_00837">ʔē</w>
                      <pc type="ws" xml:id="id_pc_2257" join="right">,</pc>
-                        <w xml:id="wid_00838" join="right">ǝṭṭēt</w>
-                     <w xml:id="wid_00839" join="right">hiyya</w>
-                     <w xml:id="wid_00840" join="right">/</w>
-                        <w xml:id="wid_00841" join="right">ǝṭṭēt</w>
-                     <w xml:id="wid_00842" join="right">hiyyāha</w>
+                        <w xml:id="wid_00838">ǝṭṭēt</w>
+                     <w xml:id="wid_00839">hiyya</w>
+                     <w xml:id="wid_00840">/</w>
+                        <w xml:id="wid_00841">ǝṭṭēt</w>
+                     <w xml:id="wid_00842">hiyyāha</w>
                      <pc type="ws" xml:id="id_pc_2266">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00843" join="right">Hast</w>
-                     <w xml:id="wid_00844" join="right">du</w>
-                     <w xml:id="wid_00845" join="right">Ahmad</w>
-                     <w xml:id="wid_00846" join="right">den</w>
-                     <w xml:id="wid_00847" join="right">Brief</w>
-                     <w xml:id="wid_00848" join="right">gegeben</w>
+                     <w xml:id="wid_00843">Hast</w>
+                     <w xml:id="wid_00844">du</w>
+                     <w xml:id="wid_00845">Ahmad</w>
+                     <w xml:id="wid_00846">den</w>
+                     <w xml:id="wid_00847">Brief</w>
+                     <w xml:id="wid_00848">gegeben</w>
                      <pc type="ws" xml:id="id_pc_2279" join="right">?</pc>
-                     <w xml:id="wid_00849" join="right">Ja</w>
+                     <w xml:id="wid_00849">Ja</w>
                      <pc type="ws" xml:id="id_pc_2281" join="right">,</pc>
-                     <w xml:id="wid_00850" join="right">ich</w>
-                     <w xml:id="wid_00851" join="right">habe</w>
-                     <w xml:id="wid_00852" join="right">ihn</w>
-                     <w xml:id="wid_00853" join="right">ihm</w>
-                     <w xml:id="wid_00854" join="right">gegeben</w>
+                     <w xml:id="wid_00850">ich</w>
+                     <w xml:id="wid_00851">habe</w>
+                     <w xml:id="wid_00852">ihn</w>
+                     <w xml:id="wid_00853">ihm</w>
+                     <w xml:id="wid_00854">gegeben</w>
                      <pc type="ws" xml:id="id_pc_2292">.</pc>
                   </quote>
                </cit>
@@ -1445,27 +1445,27 @@
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00862" join="right">ǝǧ</w>
+                     <w xml:id="wid_00862">ǝǧ</w>
                      <pc type="ws" xml:id="id_pc_2316" join="right">-</pc>
-                     <w ana="semlib:children" xml:id="wid_00863" join="right">ǧahhāl</w>
-                        <w ana="semlib:to_see" xml:id="wid_00864" join="right">šāfaw</w>
-                     <w xml:id="wid_00865" join="right">imǧaddi</w>
-                     <w xml:id="wid_00866" join="right">wara</w>
-                     <w ana="semlib:house" xml:id="wid_00867" join="right">bēt</w>
-                     <w xml:id="wid_00867a" join="right">na</w>
+                     <w ana="semlib:children" xml:id="wid_00863">ǧahhāl</w>
+                        <w ana="semlib:to_see" xml:id="wid_00864">šāfaw</w>
+                     <w xml:id="wid_00865">imǧaddi</w>
+                     <w xml:id="wid_00866">wara</w>
+                     <w ana="semlib:house" xml:id="wid_00867">bēt</w>
+                     <w xml:id="wid_00867a">na</w>
                      <pc type="ws" xml:id="id_pc_2326">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00868" join="right">Die</w>
-                     <w xml:id="wid_00869" join="right">Kinder</w>
-                     <w xml:id="wid_00870" join="right">sahen</w>
-                     <w xml:id="wid_00871" join="right">einen</w>
-                     <w xml:id="wid_00872" join="right">Bettler</w>
-                     <w xml:id="wid_00873" join="right">hinter</w>
-                     <w xml:id="wid_00874" join="right">unserem</w>
-                     <w xml:id="wid_00875" join="right">Haus</w>
+                     <w xml:id="wid_00868">Die</w>
+                     <w xml:id="wid_00869">Kinder</w>
+                     <w xml:id="wid_00870">sahen</w>
+                     <w xml:id="wid_00871">einen</w>
+                     <w xml:id="wid_00872">Bettler</w>
+                     <w xml:id="wid_00873">hinter</w>
+                     <w xml:id="wid_00874">unserem</w>
+                     <w xml:id="wid_00875">Haus</w>
                      <pc type="ws" xml:id="id_pc_2343">.</pc>
                   </quote>
                </cit>
@@ -1476,21 +1476,21 @@
                      please.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00881" join="right">ši</w>
+                     <w xml:id="wid_00881">ši</w>
                      <pc type="ws" xml:id="id_pc_2363" join="right">-</pc>
-                        <w ana="semlib:to_want" xml:id="wid_00882" join="right">trīd</w>
-                     <w xml:id="wid_00883" join="right">tišrab</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00884" join="right">gahwa</w>
-                     <w xml:id="wid_00885" join="right">lō</w>
-                     <w ana="semlib:tea" xml:id="wid_00886" join="right">čāy</w>
+                        <w ana="semlib:to_want" xml:id="wid_00882">trīd</w>
+                     <w xml:id="wid_00883">tišrab</w>
+                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00884">gahwa</w>
+                     <w xml:id="wid_00885">lō</w>
+                     <w ana="semlib:tea" xml:id="wid_00886">čāy</w>
                      <pc type="ws" xml:id="id_pc_2373" join="right">?</pc>
-                     <w xml:id="wid_00887" join="right">–</w>
-                        <w xml:id="wid_00888" join="right">ʔarīd</w>
-                     <w xml:id="wid_00889" join="right">čāy</w>
+                     <w xml:id="wid_00887">–</w>
+                        <w xml:id="wid_00888">ʔarīd</w>
+                     <w xml:id="wid_00889">čāy</w>
                      <pc type="ws" xml:id="id_pc_2380" join="right">,</pc>
                      <phr ana="semlib:please">
                      
-                        <w xml:id="wid_00890" join="right">aḷḷa</w>
+                        <w xml:id="wid_00890">aḷḷa</w>
                      
                         <w xml:id="wid_00891">yxallīk</w>
                      </phr>
@@ -1499,16 +1499,16 @@
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00892" join="right">Möchtest</w>
-                     <w xml:id="wid_00893" join="right">du</w>
-                     <w xml:id="wid_00894" join="right">Tee</w>
-                     <w xml:id="wid_00895" join="right">oder</w>
-                     <w xml:id="wid_00896" join="right">Kaffee</w>
-                     <w xml:id="wid_00897" join="right">trinken</w>
+                     <w xml:id="wid_00892">Möchtest</w>
+                     <w xml:id="wid_00893">du</w>
+                     <w xml:id="wid_00894">Tee</w>
+                     <w xml:id="wid_00895">oder</w>
+                     <w xml:id="wid_00896">Kaffee</w>
+                     <w xml:id="wid_00897">trinken</w>
                      <pc type="ws" xml:id="id_pc_2398" join="right">?</pc>
-                     <w xml:id="wid_00898" join="right">Tee</w>
+                     <w xml:id="wid_00898">Tee</w>
                      <pc type="ws" xml:id="id_pc_2400" join="right">,</pc>
-                     <w xml:id="wid_00899" join="right">bitte</w>
+                     <w xml:id="wid_00899">bitte</w>
                      <pc type="ws" xml:id="id_pc_2403">.</pc>
                   </quote>
                </cit>
@@ -1519,41 +1519,41 @@
                      you.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00911" join="right">aḷḷa</w>
-                     <w xml:id="wid_00912" join="right">yxallīk</w>
+                     <w xml:id="wid_00911">aḷḷa</w>
+                     <w xml:id="wid_00912">yxallīk</w>
                      <pc type="ws" xml:id="id_pc_2438" join="right">,</pc>
-                     <w xml:id="wid_00913" join="right">balki</w>
-                        <w ana="semlib:to_bring" xml:id="wid_00914" join="right">tǧīb</w>
+                     <w xml:id="wid_00913">balki</w>
+                        <w ana="semlib:to_bring" xml:id="wid_00914">tǧīb</w>
                      <pc type="ws" xml:id="id_pc_2443" join="right">-</pc>
-                     <w xml:id="wid_00915" join="right">li</w>
-                     <w xml:id="wid_00916" join="right">š</w>
+                     <w xml:id="wid_00915">li</w>
+                     <w xml:id="wid_00916">š</w>
                      <pc type="ws" xml:id="id_pc_2447" join="right">-</pc>
-                     <w xml:id="wid_00917" join="right">šīša</w>
-                     <w xml:id="wid_00918" join="right">č</w>
+                     <w xml:id="wid_00917">šīša</w>
+                     <w xml:id="wid_00918">č</w>
                      <pc type="ws" xml:id="id_pc_2451" join="right">-</pc>
-                     <w xml:id="wid_00919" join="right">čibīra</w>
-                     <w xml:id="wid_00920" join="right">/</w>
-                     <w xml:id="wid_00921" join="right">ǝl</w>
+                     <w xml:id="wid_00919">čibīra</w>
+                     <w xml:id="wid_00920">/</w>
+                     <w xml:id="wid_00921">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2457" join="right">-</pc>
-                     <w xml:id="wid_00922" join="right">buṭil</w>
-                     <w xml:id="wid_00923" join="right">ǝč</w>
+                     <w xml:id="wid_00922">buṭil</w>
+                     <w xml:id="wid_00923">ǝč</w>
                      <pc type="ws" xml:id="id_pc_2461" join="right">-</pc>
-                     <w xml:id="wid_00924" join="right">čibīr</w>
+                     <w xml:id="wid_00924">čibīr</w>
                      <pc type="ws" xml:id="id_pc_2463">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00925" join="right">Bring</w>
-                     <w xml:id="wid_00926" join="right">mir</w>
-                     <w xml:id="wid_00927" join="right">bitte</w>
-                     <w xml:id="wid_00928" join="right">die</w>
-                     <w xml:id="wid_00929" join="right">große</w>
-                     <w xml:id="wid_00930" join="right">Flasche</w>
+                     <w xml:id="wid_00925">Bring</w>
+                     <w xml:id="wid_00926">mir</w>
+                     <w xml:id="wid_00927">bitte</w>
+                     <w xml:id="wid_00928">die</w>
+                     <w xml:id="wid_00929">große</w>
+                     <w xml:id="wid_00930">Flasche</w>
                      <pc type="ws" xml:id="id_pc_2476" join="right">!</pc>
-                     <w xml:id="wid_00931" join="right">–</w>
-                     <w xml:id="wid_00932" join="right">Hier</w>
-                     <w xml:id="wid_00933" join="right">bitte</w>
+                     <w xml:id="wid_00931">–</w>
+                     <w xml:id="wid_00932">Hier</w>
+                     <w xml:id="wid_00933">bitte</w>
                      <pc type="ws" xml:id="id_pc_2483">.</pc>
                   </quote>
                </cit>
@@ -1563,30 +1563,30 @@
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_have" xml:id="wid_00941" join="right">ʕǝd</w>
-                     <w xml:id="wid_00942" join="right">hum</w>
-                     <w ana="semlib:much" xml:id="wid_00943" join="right">ǝhwāya</w>
-                     <w ana="semlib:money" xml:id="wid_00944" join="right">flūs</w>
-                     <w xml:id="wid_00945" join="right">bass</w>
-                     <w xml:id="wid_00946" join="right">humma</w>
-                     <w xml:id="wid_00947" join="right">mū</w>
-                     <w xml:id="wid_00948" join="right">xōš</w>
-                     <w xml:id="wid_00949" join="right">nās</w>
+                        <w ana="semlib:to_have" xml:id="wid_00941">ʕǝd</w>
+                     <w xml:id="wid_00942">hum</w>
+                     <w ana="semlib:much" xml:id="wid_00943">ǝhwāya</w>
+                     <w ana="semlib:money" xml:id="wid_00944">flūs</w>
+                     <w xml:id="wid_00945">bass</w>
+                     <w xml:id="wid_00946">humma</w>
+                     <w xml:id="wid_00947">mū</w>
+                     <w xml:id="wid_00948">xōš</w>
+                     <w xml:id="wid_00949">nās</w>
                      <pc type="ws" xml:id="id_pc_2523">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00950" join="right">Sie</w>
-                     <w xml:id="wid_00951" join="right">haben</w>
-                     <w xml:id="wid_00952" join="right">viel</w>
-                     <w xml:id="wid_00953" join="right">Geld</w>
+                     <w xml:id="wid_00950">Sie</w>
+                     <w xml:id="wid_00951">haben</w>
+                     <w xml:id="wid_00952">viel</w>
+                     <w xml:id="wid_00953">Geld</w>
                      <pc type="ws" xml:id="id_pc_2532" join="right">,</pc>
-                     <w xml:id="wid_00954" join="right">aber</w>
-                     <w xml:id="wid_00955" join="right">sie</w>
-                     <w xml:id="wid_00956" join="right">sind</w>
-                     <w xml:id="wid_00957" join="right">schlechte</w>
-                     <w xml:id="wid_00958" join="right">Leute</w>
+                     <w xml:id="wid_00954">aber</w>
+                     <w xml:id="wid_00955">sie</w>
+                     <w xml:id="wid_00956">sind</w>
+                     <w xml:id="wid_00957">schlechte</w>
+                     <w xml:id="wid_00958">Leute</w>
                      <pc type="ws" xml:id="id_pc_2543">.</pc>
                   </quote>
                </cit>
@@ -1602,22 +1602,22 @@
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00966" join="right">ǝḥna</w>
-                     <w xml:id="wid_00967" join="right">hnāya</w>
-                        <w ana="semlib:since_for" xml:id="wid_00968" join="right">mǝn</w>
-                     <w xml:id="wid_00969" join="right">ǝṯman</w>
-                     <w xml:id="wid_00970" join="right">sanawāt</w>
+                     <w xml:id="wid_00966">ǝḥna</w>
+                     <w xml:id="wid_00967">hnāya</w>
+                        <w ana="semlib:since_for" xml:id="wid_00968">mǝn</w>
+                     <w xml:id="wid_00969">ǝṯman</w>
+                     <w xml:id="wid_00970">sanawāt</w>
                      <pc type="ws" xml:id="id_pc_2586">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_00971" join="right">Wir</w>
-                     <w xml:id="wid_00972" join="right">sind</w>
-                     <w xml:id="wid_00973" join="right">seit</w>
-                     <w xml:id="wid_00974" join="right">8</w>
-                     <w xml:id="wid_00975" join="right">Jahren</w>
-                     <w xml:id="wid_00976" join="right">hier</w>
+                     <w xml:id="wid_00971">Wir</w>
+                     <w xml:id="wid_00972">sind</w>
+                     <w xml:id="wid_00973">seit</w>
+                     <w xml:id="wid_00974">8</w>
+                     <w xml:id="wid_00975">Jahren</w>
+                     <w xml:id="wid_00976">hier</w>
                      <pc type="ws" xml:id="id_pc_2599">.</pc>
                   </quote>
                </cit>
@@ -1631,44 +1631,44 @@
                      bread.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_00982" join="right">ǝš</w>
+                     <w xml:id="wid_00982">ǝš</w>
                      <pc type="ws" xml:id="id_pc_2629" join="right">-</pc>
-                     <w xml:id="wid_00983" join="right">da</w>
+                     <w xml:id="wid_00983">da</w>
                      <pc type="ws" xml:id="id_pc_2631" join="right">-</pc>
-                     <w xml:id="wid_00984" join="right">ysawwūn</w>
-                     <w xml:id="wid_00985" join="right">ysawwan</w>
-                     <w xml:id="wid_00986" join="right">haḏōlāk</w>
-                        <w xml:id="wid_00987" join="right">in</w>
+                     <w xml:id="wid_00984">ysawwūn</w>
+                     <w xml:id="wid_00985">ysawwan</w>
+                     <w xml:id="wid_00986">haḏōlāk</w>
+                        <w xml:id="wid_00987">in</w>
                         <pc type="ws" xml:id="id_pc_2639" join="right">-</pc>
-                        <w ana="semlib:women" xml:id="wid_00988" join="right">nǝswān</w>
+                        <w ana="semlib:women" xml:id="wid_00988">nǝswān</w>
                      <pc type="ws" xml:id="id_pc_2641" join="right">?</pc>
-                     <w xml:id="wid_00989" join="right">–</w>
-                     <w xml:id="wid_00990" join="right">gāʕǝd</w>
-                     <w xml:id="wid_00991" join="right">yxubzūn</w>
-                     <w xml:id="wid_00992" join="right">/</w>
-                     <w xml:id="wid_00993" join="right">gāʕǝd</w>
-                     <w xml:id="wid_00994" join="right">yxubzan</w>
-                     <w xml:id="wid_00995" join="right">/</w>
-                     <w xml:id="wid_00996" join="right">gāʕdāt</w>
-                     <w xml:id="wid_00997" join="right">yxubzan</w>
-                     <w xml:id="wid_00998" join="right">/</w>
-                     <w xml:id="wid_00999" join="right">gāʕdīn</w>
-                     <w xml:id="wid_01000" join="right">yxubzūn</w>
+                     <w xml:id="wid_00989">–</w>
+                     <w xml:id="wid_00990">gāʕǝd</w>
+                     <w xml:id="wid_00991">yxubzūn</w>
+                     <w xml:id="wid_00992">/</w>
+                     <w xml:id="wid_00993">gāʕǝd</w>
+                     <w xml:id="wid_00994">yxubzan</w>
+                     <w xml:id="wid_00995">/</w>
+                     <w xml:id="wid_00996">gāʕdāt</w>
+                     <w xml:id="wid_00997">yxubzan</w>
+                     <w xml:id="wid_00998">/</w>
+                     <w xml:id="wid_00999">gāʕdīn</w>
+                     <w xml:id="wid_01000">yxubzūn</w>
                      <pc type="ws" xml:id="id_pc_2666">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01001" join="right">Was</w>
-                     <w xml:id="wid_01002" join="right">machen</w>
-                     <w xml:id="wid_01003" join="right">jene</w>
-                     <w xml:id="wid_01004" join="right">Frauen</w>
-                     <w xml:id="wid_01005" join="right">dort</w>
+                     <w xml:id="wid_01001">Was</w>
+                     <w xml:id="wid_01002">machen</w>
+                     <w xml:id="wid_01003">jene</w>
+                     <w xml:id="wid_01004">Frauen</w>
+                     <w xml:id="wid_01005">dort</w>
                      <pc type="ws" xml:id="id_pc_2677" join="right">?</pc>
-                     <w xml:id="wid_01006" join="right">–</w>
-                     <w xml:id="wid_01007" join="right">Sie</w>
-                     <w xml:id="wid_01008" join="right">backen</w>
-                     <w xml:id="wid_01009" join="right">Brot</w>
+                     <w xml:id="wid_01006">–</w>
+                     <w xml:id="wid_01007">Sie</w>
+                     <w xml:id="wid_01008">backen</w>
+                     <w xml:id="wid_01009">Brot</w>
                      <pc type="ws" xml:id="id_pc_2686">.</pc>
                   </quote>
                </cit>
@@ -1679,34 +1679,34 @@
                      car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01016" join="right">yǝlbas</w>
-                        <w ana="semlib:husband" xml:id="wid_01017" join="right">raǧl</w>
-                     <w xml:id="id_w_0" join="right">i</w>
-                     <w xml:id="wid_01018" join="right">qamīṣ</w>
-                     <w xml:id="wid_01019" join="right">ʔabyað̣</w>
-                     <w xml:id="wid_01020" join="right">w</w>
+                     <w xml:id="wid_01016">yǝlbas</w>
+                        <w ana="semlib:husband" xml:id="wid_01017">raǧl</w>
+                     <w xml:id="id_w_0">i</w>
+                     <w xml:id="wid_01018">qamīṣ</w>
+                     <w xml:id="wid_01019">ʔabyað̣</w>
+                     <w xml:id="wid_01020">w</w>
                      <pc type="ws" xml:id="id_pc_2716" join="right">-</pc>
-                     <w xml:id="wid_01021" join="right">ʔāni</w>
-                     <w xml:id="wid_01022" join="right">ʔalbas</w>
-                     <w xml:id="wid_01023" join="right">badla</w>
-                     <w xml:id="wid_01024" join="right">bēð̣a</w>
+                     <w xml:id="wid_01021">ʔāni</w>
+                     <w xml:id="wid_01022">ʔalbas</w>
+                     <w xml:id="wid_01023">badla</w>
+                     <w xml:id="wid_01024">bēð̣a</w>
                      <pc type="ws" xml:id="id_pc_2724">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01025" join="right">Mein</w>
-                     <w xml:id="wid_01026" join="right">Mann</w>
-                     <w xml:id="wid_01027" join="right">trägt</w>
-                     <w xml:id="wid_01028" join="right">ein</w>
-                     <w xml:id="wid_01029" join="right">weißes</w>
-                     <w xml:id="wid_01030" join="right">Hemd</w>
-                     <w xml:id="wid_01031" join="right">und</w>
-                     <w xml:id="wid_01032" join="right">ich</w>
-                     <w xml:id="wid_01033" join="right">trage</w>
-                     <w xml:id="wid_01034" join="right">ein</w>
-                     <w xml:id="wid_01035" join="right">weißes</w>
-                     <w xml:id="wid_01036" join="right">Kleid</w>
+                     <w xml:id="wid_01025">Mein</w>
+                     <w xml:id="wid_01026">Mann</w>
+                     <w xml:id="wid_01027">trägt</w>
+                     <w xml:id="wid_01028">ein</w>
+                     <w xml:id="wid_01029">weißes</w>
+                     <w xml:id="wid_01030">Hemd</w>
+                     <w xml:id="wid_01031">und</w>
+                     <w xml:id="wid_01032">ich</w>
+                     <w xml:id="wid_01033">trage</w>
+                     <w xml:id="wid_01034">ein</w>
+                     <w xml:id="wid_01035">weißes</w>
+                     <w xml:id="wid_01036">Kleid</w>
                      <pc type="ws" xml:id="id_pc_2749">.</pc>
                   </quote>
                </cit>
@@ -1716,31 +1716,31 @@
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01045" join="right">mǝnu</w>
-                     <w xml:id="wid_01046" join="right">hāḏa</w>
-                     <w xml:id="wid_01047" join="right">r</w>
+                     <w xml:id="wid_01045">mǝnu</w>
+                     <w xml:id="wid_01046">hāḏa</w>
+                     <w xml:id="wid_01047">r</w>
                      <pc type="ws" xml:id="id_pc_2778" join="right">-</pc>
-                     <w xml:id="wid_01048" join="right">rǝǧǧāl</w>
+                     <w xml:id="wid_01048">rǝǧǧāl</w>
                      <pc type="ws" xml:id="id_pc_2780" join="right">?</pc>
-                     <w xml:id="wid_01049" join="right">–</w>
-                     <w xml:id="wid_01050" join="right">huwwa</w>
-                        <w ana="semlib:friend" xml:id="wid_01051" join="right">ṣadīq</w>
-                     <w xml:id="wid_01052" join="right">i</w>
+                     <w xml:id="wid_01049">–</w>
+                     <w xml:id="wid_01050">huwwa</w>
+                        <w ana="semlib:friend" xml:id="wid_01051">ṣadīq</w>
+                     <w xml:id="wid_01052">i</w>
                      <pc type="ws" xml:id="id_pc_2788">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01053" join="right">Wer</w>
-                     <w xml:id="wid_01054" join="right">ist</w>
-                     <w xml:id="wid_01055" join="right">dieser</w>
-                     <w xml:id="wid_01056" join="right">Mann</w>
+                     <w xml:id="wid_01053">Wer</w>
+                     <w xml:id="wid_01054">ist</w>
+                     <w xml:id="wid_01055">dieser</w>
+                     <w xml:id="wid_01056">Mann</w>
                      <pc type="ws" xml:id="id_pc_2797" join="right">?</pc>
-                     <w xml:id="wid_01057" join="right">–</w>
-                     <w xml:id="wid_01058" join="right">Er</w>
-                     <w xml:id="wid_01059" join="right">ist</w>
-                     <w xml:id="wid_01060" join="right">mein</w>
-                     <w xml:id="wid_01061" join="right">Freund</w>
+                     <w xml:id="wid_01057">–</w>
+                     <w xml:id="wid_01058">Er</w>
+                     <w xml:id="wid_01059">ist</w>
+                     <w xml:id="wid_01060">mein</w>
+                     <w xml:id="wid_01061">Freund</w>
                      <pc type="ws" xml:id="id_pc_2808">.</pc>
                   </quote>
                </cit>
@@ -1753,28 +1753,28 @@
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01067" join="right">wēn</w>
-                     <w xml:id="wid_01068" join="right">ǝl</w>
+                     <w xml:id="wid_01067">wēn</w>
+                     <w xml:id="wid_01068">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2839" join="right">-</pc>
-                        <w ana="semlib:mobile" xml:id="wid_01069" join="right">mōbāyl</w>
-                     <w xml:id="wid_01070" join="right">mālti</w>
+                        <w ana="semlib:mobile" xml:id="wid_01069">mōbāyl</w>
+                     <w xml:id="wid_01070">mālti</w>
                      <pc type="ws" xml:id="id_pc_2843" join="right">?</pc>
-                     <w xml:id="wid_01071" join="right">–</w>
-                     <w xml:id="wid_01072" join="right">hayyāta</w>
+                     <w xml:id="wid_01071">–</w>
+                     <w xml:id="wid_01072">hayyāta</w>
                      <pc type="ws" xml:id="id_pc_2848">!</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01073" join="right">Wo</w>
-                     <w xml:id="wid_01074" join="right">ist</w>
-                     <w xml:id="wid_01075" join="right">mein</w>
-                     <w xml:id="wid_01076" join="right">Handy</w>
+                     <w xml:id="wid_01073">Wo</w>
+                     <w xml:id="wid_01074">ist</w>
+                     <w xml:id="wid_01075">mein</w>
+                     <w xml:id="wid_01076">Handy</w>
                      <pc type="ws" xml:id="id_pc_2857" join="right">?</pc>
-                     <w xml:id="wid_01077" join="right">–</w>
-                     <w xml:id="wid_01078" join="right">Da</w>
-                     <w xml:id="wid_01079" join="right">ist</w>
-                     <w xml:id="wid_01080" join="right">es</w>
+                     <w xml:id="wid_01077">–</w>
+                     <w xml:id="wid_01078">Da</w>
+                     <w xml:id="wid_01079">ist</w>
+                     <w xml:id="wid_01080">es</w>
                      <pc type="ws" xml:id="id_pc_2866">!</pc>
                   </quote>
                </cit>
@@ -1788,27 +1788,27 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <phr ana="semlib:being_unable">
-                        <w xml:id="wid_01086" join="right">ma</w>
+                        <w xml:id="wid_01086">ma</w>
                      
                      
                         <w xml:id="wid_01087">nǝgdar</w>
                      
                      </phr>
-                     <w xml:id="wid_01088" join="right">nǝdfaʕ</w>
-                     <w xml:id="wid_01089" join="right">l</w>
+                     <w xml:id="wid_01088">nǝdfaʕ</w>
+                     <w xml:id="wid_01089">l</w>
                      <pc type="ws" xml:id="id_pc_2903" join="right">-</pc>
-                     <w xml:id="wid_01090" join="right">īǧār</w>
+                     <w xml:id="wid_01090">īǧār</w>
                      <pc type="ws" xml:id="id_pc_2905">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01091" join="right">Wir</w>
-                     <w xml:id="wid_01092" join="right">können</w>
-                     <w xml:id="wid_01093" join="right">die</w>
-                     <w xml:id="wid_01094" join="right">Miete</w>
-                     <w xml:id="wid_01095" join="right">nicht</w>
-                     <w xml:id="wid_01096" join="right">zahlen</w>
+                     <w xml:id="wid_01091">Wir</w>
+                     <w xml:id="wid_01092">können</w>
+                     <w xml:id="wid_01093">die</w>
+                     <w xml:id="wid_01094">Miete</w>
+                     <w xml:id="wid_01095">nicht</w>
+                     <w xml:id="wid_01096">zahlen</w>
                      <pc type="ws" xml:id="id_pc_2918">.</pc>
                   </quote>
                </cit>
@@ -1818,26 +1818,26 @@
                <quote xml:lang="en">Can you (~do you know how to) play domino? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01102" join="right">tilʕab</w>
-                     <w xml:id="wid_01103" join="right">dōmna</w>
+                     <w xml:id="wid_01102">tilʕab</w>
+                     <w xml:id="wid_01103">dōmna</w>
                      <pc type="ws" xml:id="id_pc_2939" join="right">?</pc>
-                     <w xml:id="wid_01104" join="right">–</w>
-                     <w xml:id="wid_01105" join="right">ʔē</w>
+                     <w xml:id="wid_01104">–</w>
+                     <w xml:id="wid_01105">ʔē</w>
                      <pc type="ws" xml:id="id_pc_2944" join="right">,</pc>
-                     <w xml:id="wid_01106" join="right">ʔalʕab</w>
-                     <w xml:id="wid_01107" join="right">dōmna</w>
+                     <w xml:id="wid_01106">ʔalʕab</w>
+                     <w xml:id="wid_01107">dōmna</w>
                      <pc type="ws" xml:id="id_pc_2949">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01108" join="right">Kannst</w>
-                     <w xml:id="wid_01109" join="right">du</w>
-                     <w xml:id="wid_01110" join="right">Domino</w>
-                     <w xml:id="wid_01111" join="right">spielen</w>
+                     <w xml:id="wid_01108">Kannst</w>
+                     <w xml:id="wid_01109">du</w>
+                     <w xml:id="wid_01110">Domino</w>
+                     <w xml:id="wid_01111">spielen</w>
                      <pc type="ws" xml:id="id_pc_2958" join="right">?</pc>
-                     <w xml:id="wid_01112" join="right">–</w>
-                     <w xml:id="wid_01113" join="right">Ja</w>
+                     <w xml:id="wid_01112">–</w>
+                     <w xml:id="wid_01113">Ja</w>
                      <pc type="ws" xml:id="id_pc_2963">.</pc>
                   </quote>
                </cit>
@@ -1850,10 +1850,10 @@
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01118" join="right">Kannst</w>
-                     <w xml:id="wid_01119" join="right">Du</w>
-                     <w xml:id="wid_01120" join="right">morgen</w>
-                     <w xml:id="wid_01121" join="right">kommen</w>
+                     <w xml:id="wid_01118">Kannst</w>
+                     <w xml:id="wid_01119">Du</w>
+                     <w xml:id="wid_01120">morgen</w>
+                     <w xml:id="wid_01121">kommen</w>
                      <pc type="ws" xml:id="id_pc_2990">?</pc>
                   </quote>
                </cit>
@@ -1866,25 +1866,25 @@
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01122" join="right">tǝḥči</w>
-                     <w xml:id="wid_01123" join="right">ʕarabi</w>
+                     <w xml:id="wid_01122">tǝḥči</w>
+                     <w xml:id="wid_01123">ʕarabi</w>
                      <pc type="ws" xml:id="id_pc_3011" join="right">?</pc>
-                     <w xml:id="wid_01124" join="right">–</w>
-                     <w xml:id="wid_01125" join="right">bass</w>
-                        <w ana="semlib:a_little" xml:id="wid_01126" join="right">ǝšwayya</w>
+                     <w xml:id="wid_01124">–</w>
+                     <w xml:id="wid_01125">bass</w>
+                        <w ana="semlib:a_little" xml:id="wid_01126">ǝšwayya</w>
                      <pc type="ws" xml:id="id_pc_3018">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01127" join="right">Sprichst</w>
-                     <w xml:id="wid_01128" join="right">du</w>
-                     <w xml:id="wid_01129" join="right">Arabisch</w>
+                     <w xml:id="wid_01127">Sprichst</w>
+                     <w xml:id="wid_01128">du</w>
+                     <w xml:id="wid_01129">Arabisch</w>
                      <pc type="ws" xml:id="id_pc_3025" join="right">?</pc>
-                     <w xml:id="wid_01130" join="right">–</w>
-                     <w xml:id="wid_01131" join="right">Nur</w>
-                     <w xml:id="wid_01132" join="right">ein</w>
-                     <w xml:id="wid_01133" join="right">bißchen</w>
+                     <w xml:id="wid_01130">–</w>
+                     <w xml:id="wid_01131">Nur</w>
+                     <w xml:id="wid_01132">ein</w>
+                     <w xml:id="wid_01133">bißchen</w>
                      <pc type="ws" xml:id="id_pc_3034">.</pc>
                   </quote>
                </cit>
@@ -1894,24 +1894,24 @@
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01139" join="right">ǝb</w>
+                     <w xml:id="wid_01139">ǝb</w>
                      <pc type="ws" xml:id="id_pc_3053" join="right">-</pc>
-                     <w xml:id="wid_01140" join="right">ṣaffna</w>
-                     <w xml:id="wid_01141" join="right">ṯmunṭaʕaš</w>
-                     <w xml:id="wid_01142" join="right">ṭālib</w>
-                     <w xml:id="wid_01143" join="right">ǝǧdīd</w>
+                     <w xml:id="wid_01140">ṣaffna</w>
+                     <w xml:id="wid_01141">ṯmunṭaʕaš</w>
+                     <w xml:id="wid_01142">ṭālib</w>
+                     <w xml:id="wid_01143">ǝǧdīd</w>
                      <pc type="ws" xml:id="id_pc_3061">.</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01144" join="right">In</w>
-                     <w xml:id="wid_01145" join="right">unserer</w>
-                     <w xml:id="wid_01146" join="right">Klasse</w>
-                     <w xml:id="wid_01147" join="right">sind</w>
-                     <w xml:id="wid_01148" join="right">18</w>
-                     <w xml:id="wid_01149" join="right">neue</w>
-                     <w xml:id="wid_01150" join="right">Studenten</w>
+                     <w xml:id="wid_01144">In</w>
+                     <w xml:id="wid_01145">unserer</w>
+                     <w xml:id="wid_01146">Klasse</w>
+                     <w xml:id="wid_01147">sind</w>
+                     <w xml:id="wid_01148">18</w>
+                     <w xml:id="wid_01149">neue</w>
+                     <w xml:id="wid_01150">Studenten</w>
                      <pc type="ws" xml:id="id_pc_3076">.</pc>
                   </quote>
                </cit>
@@ -1921,29 +1921,29 @@
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w xml:id="wid_01156" join="right">wēn</w>
-                     <w xml:id="wid_01157" join="right">ǝl</w>
+                     <w xml:id="wid_01156">wēn</w>
+                     <w xml:id="wid_01157">ǝl</w>
                      <pc type="ws" xml:id="id_pc_3097" join="right">-</pc>
-                     <w xml:id="wid_01158" join="right">mōbāyl</w>
-                        <w ana="fvlib:pres_f_sg" xml:id="wid_01159" join="right">mālt</w>
-                     <w xml:id="wid_01160" join="right">i</w>
+                     <w xml:id="wid_01158">mōbāyl</w>
+                        <w ana="fvlib:pres_f_sg" xml:id="wid_01159">mālt</w>
+                     <w xml:id="wid_01160">i</w>
                      <pc type="ws" xml:id="id_pc_3102" join="right">?</pc>
-                     <w xml:id="wid_01161" join="right">–</w>
-                     <w xml:id="wid_01162" join="right">hayyāta</w>
+                     <w xml:id="wid_01161">–</w>
+                     <w xml:id="wid_01162">hayyāta</w>
                      <pc type="ws" xml:id="id_pc_3107">!</pc>
                   </quote>
                </cit>
                <cit type="translation">
                   <quote xml:lang="de">
-                     <w xml:id="wid_01163" join="right">Wo</w>
-                     <w xml:id="wid_01164" join="right">ist</w>
-                     <w xml:id="wid_01165" join="right">mein</w>
-                     <w xml:id="wid_01166" join="right">Handy</w>
+                     <w xml:id="wid_01163">Wo</w>
+                     <w xml:id="wid_01164">ist</w>
+                     <w xml:id="wid_01165">mein</w>
+                     <w xml:id="wid_01166">Handy</w>
                      <pc type="ws" xml:id="id_pc_3116" join="right">?</pc>
-                     <w xml:id="wid_01167" join="right">–</w>
-                     <w xml:id="wid_01168" join="right">Da</w>
-                     <w xml:id="wid_01169" join="right">ist</w>
-                     <w xml:id="wid_01170" join="right">es</w>
+                     <w xml:id="wid_01167">–</w>
+                     <w xml:id="wid_01168">Da</w>
+                     <w xml:id="wid_01169">ist</w>
+                     <w xml:id="wid_01170">es</w>
                      <pc type="ws" xml:id="id_pc_3125">!</pc>
                   </quote>
                </cit>

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p xml:id="id_p_12">
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -163,7 +158,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semLib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -198,7 +193,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semLib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
@@ -232,7 +227,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semLib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -320,7 +315,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semLib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -359,7 +354,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semLib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -481,7 +476,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semLib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
@@ -525,7 +520,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit ana="fvLib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -579,7 +574,7 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit type="featureSample">
+            <cit ana="fvLib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
@@ -634,7 +629,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="vtLex:here">
+            <cit ana="vtLex:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -659,7 +654,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:now">
+            <cit ana="vtLex:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -698,7 +693,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:today">
+            <cit ana="vtLex:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -727,7 +722,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:yesterday">
+            <cit ana="vtLex:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -755,7 +750,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:tomorrow">
+            <cit ana="vtLex:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -781,7 +776,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:last_year">
+            <cit ana="vtLex:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -825,7 +820,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="vtLex:eight">
+            <cit ana="vtLex:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -850,7 +845,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:eleven">
+            <cit ana="vtLex:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -886,7 +881,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:twelve">
+            <cit ana="vtLex:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -915,7 +910,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:eighteen">
+            <cit ana="vtLex:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -945,7 +940,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="vtLex:good">
+            <cit ana="vtLex:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -987,7 +982,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="vtLex:white">
+            <cit ana="vtLex:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1024,7 +1019,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:black">
+            <cit ana="vtLex:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -1064,7 +1059,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:pink">
+            <cit ana="vtLex:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -1095,7 +1090,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:grey">
+            <cit ana="vtLex:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
@@ -1122,7 +1117,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:orange">
+            <cit ana="vtLex:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
@@ -1145,7 +1140,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semLib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -1177,7 +1172,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="vtLex:to_do">
+            <cit ana="vtLex:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -1218,7 +1213,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_stay">
+            <cit ana="vtLex:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -1268,7 +1263,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_speak">
+            <cit ana="vtLex:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1296,7 +1291,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_rain">
+            <cit ana="vtLex:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -1325,7 +1320,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_open">
+            <cit ana="vtLex:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -1347,7 +1342,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_close">
+            <cit ana="vtLex:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -1368,7 +1363,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_take">
+            <cit ana="vtLex:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1401,7 +1396,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_give">
+            <cit ana="vtLex:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
@@ -1446,7 +1441,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_see">
+            <cit ana="vtLex:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1476,7 +1471,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_want">
+            <cit ana="vtLex:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
@@ -1519,7 +1514,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_bring">
+            <cit ana="vtLex:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
@@ -1564,7 +1559,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:to_have">
+            <cit ana="vtLex:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1600,7 +1595,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semLib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
@@ -1631,7 +1626,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="vtLex:women">
+            <cit ana="vtLex:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
@@ -1679,7 +1674,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:husband">
+            <cit ana="vtLex:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1717,7 +1712,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:friend">
+            <cit ana="vtLex:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -1754,7 +1749,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semLib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1788,7 +1783,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="vtLex:being_unable">
+            <cit ana="vtLex:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1819,7 +1814,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:ability">
+            <cit ana="vtLex:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play domino? – Yes.</quote>
                <cit type="translation">
@@ -1848,7 +1843,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="vtLex:possibility">
+            <cit ana="vtLex:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1867,7 +1862,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="vtLex:a_little">
+            <cit ana="vtLex:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1922,7 +1917,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="fvLib:pres_f_sg" type="featureSample">
                <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="ling_features_baghdad">
+<?xml version="1.0" encoding="UTF-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="ling_features_baghdad">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -40,20 +39,20 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                         <w ana="semLib:who" xml:id="wid_00000" join="right">mǝnu</w>
+                         <w ana="semlib:who" xml:id="wid_00000" join="right">mǝnu</w>
                      <w xml:id="wid_00001" join="right">hāḏa</w>
                      <w xml:id="wid_00002" join="right">r</w>
                      <pc type="ws" xml:id="id_pc_52" join="right">-</pc>
-                     <w ana="semLib:man" xml:id="wid_00003" join="right">rǝǧǧāl</w>
+                     <w ana="semlib:man" xml:id="wid_00003" join="right">rǝǧǧāl</w>
                      <pc type="ws" xml:id="id_pc_54" join="right">?</pc>
                      <w xml:id="wid_00004" join="right">–</w>
-                     <w ana="fvLib:perspron_3_sg_m" xml:id="wid_00005" join="right">huwwa</w>
+                     <w ana="fvlib:perspron_3_sg_m" xml:id="wid_00005" join="right">huwwa</w>
                      <w xml:id="wid_00006" join="right">ṣadīq</w>
                      <w xml:id="id_w_1" join="right">i</w>
                      <pc type="ws" xml:id="id_pc_61">.</pc>
@@ -75,15 +74,15 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w ana="fvLib:dempron_prox_f_sg" xml:id="wid_00021" join="right">hāḏi</w>
-                     <w ana="semLib:car" xml:id="wid_00022" join="right">siyyārat</w>
-                        <w ana="semLib:whose" xml:id="wid_00023" join="right">mǝnu</w>
+                     <w ana="fvlib:dempron_prox_f_sg" xml:id="wid_00021" join="right">hāḏi</w>
+                     <w ana="semlib:car" xml:id="wid_00022" join="right">siyyārat</w>
+                        <w ana="semlib:whose" xml:id="wid_00023" join="right">mǝnu</w>
                      <pc type="ws" xml:id="id_pc_105" join="right">?</pc>
                      <w xml:id="wid_00024" join="right">–</w>
                      <w xml:id="wid_00025" join="right">hāḏi</w>
@@ -119,14 +118,14 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00054" join="right">Fāṭma</w>
                      <pc type="ws" xml:id="id_pc_181" join="right">,</pc>
-                        <w ana="semLib:what" xml:id="wid_00055" join="right">ǝš</w>
+                        <w ana="semlib:what" xml:id="wid_00055" join="right">ǝš</w>
                      <pc type="ws" xml:id="id_pc_184" join="right">-</pc>
                      <w xml:id="wid_00056" join="right">da</w>
                      <pc type="ws" xml:id="id_pc_186" join="right">-</pc>
@@ -137,7 +136,7 @@
                      <w xml:id="wid_00060" join="right">ʔašūf</w>
                      <w xml:id="wid_00061" join="right">ǝt</w>
                      <pc type="ws" xml:id="id_pc_197" join="right">-</pc>
-                     <w ana="semLib:TV" xml:id="wid_00062" join="right">talfizyōn</w>
+                     <w ana="semlib:TV" xml:id="wid_00062" join="right">talfizyōn</w>
                      <pc type="ws" xml:id="id_pc_199">.</pc>
                   </quote>
                </cit>
@@ -158,7 +157,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semLib:why" type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -166,7 +165,7 @@
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:why" xml:id="wid_00079" join="right">lēš</w>
+                        <w ana="semlib:why" xml:id="wid_00079" join="right">lēš</w>
                      <w xml:id="wid_00080" join="right">ma</w>
                      <w xml:id="wid_00081" join="right">ʔǝǧa</w>
                      <pc type="ws" xml:id="id_pc_251" join="right">?</pc>
@@ -193,7 +192,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semLib:where" type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
@@ -201,7 +200,7 @@
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:where" xml:id="wid_00100" join="right">wēn</w>
+                        <w ana="semlib:where" xml:id="wid_00100" join="right">wēn</w>
                      <w xml:id="wid_00101" join="right">ǝl</w>
                      <pc type="ws" xml:id="id_pc_304" join="right">-</pc>
                      <w xml:id="wid_00102" join="right">mōbāyl</w>
@@ -227,12 +226,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semLib:where_to" type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:where_to" xml:id="wid_00119" join="right">wēn</w>
+                        <w ana="semlib:where_to" xml:id="wid_00119" join="right">wēn</w>
                      <w xml:id="wid_00120" join="right">rāḥ</w>
                      <w xml:id="wid_00121" join="right">ǝtrūḥ</w>
                      <pc type="ws" xml:id="id_pc_357" join="right">?</pc>
@@ -269,26 +268,26 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Cairo.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:where_from" xml:id="wid_00148" join="right">ǝmmēn</w>
-                     <w ana="fvLib:perspron_2_sg_m" xml:id="wid_00149" join="right">ǝnta</w>
+                        <w ana="semlib:where_from" xml:id="wid_00148" join="right">ǝmmēn</w>
+                     <w ana="fvlib:perspron_2_sg_m" xml:id="wid_00149" join="right">ǝnta</w>
                      <w xml:id="wid_00150" join="right">/</w>
-                     <w ana="fvLib:perspron_2_sg_f" xml:id="wid_00151" join="right">ǝnti</w>
+                     <w ana="fvlib:perspron_2_sg_f" xml:id="wid_00151" join="right">ǝnti</w>
                      <w xml:id="wid_00152" join="right">/</w>
-                     <w ana="fvLib:perspron_2_pl" xml:id="wid_00153" join="right">ǝntu</w>
+                     <w ana="fvlib:perspron_2_pl" xml:id="wid_00153" join="right">ǝntu</w>
                      <pc type="ws" xml:id="id_pc_439" join="right">?</pc>
                      <w xml:id="wid_00154" join="right">–</w>
-                     <w ana="fvLib:perspron_1_sg" xml:id="wid_00155" join="right">ʔāni</w>
+                     <w ana="fvlib:perspron_1_sg" xml:id="wid_00155" join="right">ʔāni</w>
                      <w xml:id="wid_00156" join="right">mǝn</w>
                      <w xml:id="wid_00157" join="right">baġdād</w>
                      <pc type="ws" xml:id="id_pc_448" join="right">.</pc>
                      <w xml:id="wid_00158" join="right">/</w>
-                     <w ana="fvLib:perspron_1_pl" xml:id="wid_00159" join="right">ǝḥna</w>
+                     <w ana="fvlib:perspron_1_pl" xml:id="wid_00159" join="right">ǝḥna</w>
                      <w xml:id="wid_00160" join="right">mǝn</w>
                      <w xml:id="wid_00161" join="right">baġdād</w>
                      <pc type="ws" xml:id="id_pc_457">.</pc>
@@ -315,7 +314,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semLib:when" type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -323,7 +322,7 @@
                      <w xml:id="wid_00185" join="right">ya</w>
                      <w xml:id="wid_00186" join="right">Fāṭma</w>
                      <pc type="ws" xml:id="id_pc_520" join="right">,</pc>
-                        <w ana="semLib:when" xml:id="wid_00187" join="right">ǝšwakǝt</w>
+                        <w ana="semlib:when" xml:id="wid_00187" join="right">ǝšwakǝt</w>
                      <w xml:id="wid_00188" join="right">šǝfti</w>
                      <w xml:id="wid_00189" join="right">Mḥammad</w>
                      <pc type="ws" xml:id="id_pc_527" join="right">?</pc>
@@ -354,12 +353,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semLib:how" type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:how" xml:id="wid_00212" join="right">ǝšlōn</w>
+                        <w ana="semlib:how" xml:id="wid_00212" join="right">ǝšlōn</w>
                      <w xml:id="wid_00213" join="right">ak</w>
                      <w xml:id="wid_00214" join="right">/</w>
                         <w xml:id="wid_00215" join="right">ǝšlōn</w>
@@ -395,16 +394,16 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_much" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:how_much" xml:id="wid_00239" join="right">bēš</w>
+                        <w ana="semlib:how_much" xml:id="wid_00239" join="right">bēš</w>
                      <w xml:id="wid_00240" join="right">nuṣṣ</w>
                      <w xml:id="wid_00241" join="right">kēlu</w>
                      <w xml:id="wid_00242" join="right">nūmi</w>
-                     <w ana="semLib:lemon" xml:id="wid_00243" join="right">ḥāmuð̣</w>
+                     <w ana="semlib:lemon" xml:id="wid_00243" join="right">ḥāmuð̣</w>
                      <pc type="ws" xml:id="id_pc_660" join="right">.</pc>
                      <w xml:id="wid_00244" join="right">–</w>
                      <w xml:id="wid_00245" join="right">sǝʕra</w>
@@ -431,14 +430,14 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
                      and three sons.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:how_many" xml:id="wid_00265" join="right">ǝšgadd</w>
+                        <w ana="semlib:how_many" xml:id="wid_00265" join="right">ǝšgadd</w>
                      <w xml:id="wid_00266" join="right">ʕǝddǝč</w>
                      <w xml:id="wid_00267" join="right">ǧahhāl</w>
                      <pc type="ws" xml:id="id_pc_723" join="right">?</pc>
@@ -452,7 +451,7 @@
                      <w xml:id="wid_00274" join="right">bǝntēn</w>
                      <w xml:id="wid_00275" join="right">wǝ</w>
                      <pc type="ws" xml:id="id_pc_741" join="right">-</pc>
-                     <w ana="semLib:three #vt_phon_CA_th" xml:id="wid_00276" join="right">tlaṯ</w>
+                     <w ana="semlib:three #vt_phon_CA_th" xml:id="wid_00276" join="right">tlaṯ</w>
                      <w xml:id="wid_00277" join="right">wǝlǝd</w>
                      <pc type="ws" xml:id="id_pc_745">.</pc>
                   </quote>
@@ -476,14 +475,14 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semLib:which" type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00297" join="right">ǝb</w>
                      <pc type="ws" xml:id="id_pc_794" join="right">-</pc>
-                        <w ana="semLib:which" xml:id="wid_00298" join="right">ʔayy</w>
+                        <w ana="semlib:which" xml:id="wid_00298" join="right">ʔayy</w>
                      <w xml:id="wid_00299" join="right">manṭiqa</w>
                      <w xml:id="wid_00300" join="right">tsuknūn</w>
                      <pc type="ws" xml:id="id_pc_800" join="right">?</pc>
@@ -520,13 +519,13 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit ana="fvLib:dempron_prox_m_sg" type="featureSample">
+            <cit ana="fvlib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00325" join="right">mǝnu</w>
-                        <w ana="fvLib:dempron_prox_m_sg" xml:id="wid_00326" join="right">hāḏa</w>
+                        <w ana="fvlib:dempron_prox_m_sg" xml:id="wid_00326" join="right">hāḏa</w>
                      <w xml:id="wid_00327" join="right">r</w>
                      <pc type="ws" xml:id="id_pc_876" join="right">-</pc>
                      <w xml:id="wid_00328" join="right">rǝǧǧāl</w>
@@ -574,7 +573,7 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit ana="fvLib:pres_m_sg" type="featureSample">
+            <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
@@ -586,7 +585,7 @@
                      <w xml:id="wid_00352" join="right">mālti</w>
                      <pc type="ws" xml:id="id_pc_964" join="right">?</pc>
                      <w xml:id="wid_00353" join="right">–</w>
-                        <w ana="fvLib:pres_m_sg" xml:id="wid_00354" join="right">hayyāta</w>
+                        <w ana="fvlib:pres_m_sg" xml:id="wid_00354" join="right">hayyāta</w>
                      <pc type="ws" xml:id="id_pc_969">!</pc>
                   </quote>
                </cit>
@@ -629,13 +628,13 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit ana="vtLex:here" type="featureSample">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00371" join="right">ǝḥna</w>
-                        <w ana="semLib:here" xml:id="wid_00372" join="right">hnāya</w>
+                        <w ana="semlib:here" xml:id="wid_00372" join="right">hnāya</w>
                      <w xml:id="wid_00373" join="right">mǝn</w>
                      <w xml:id="wid_00374" join="right">ǝṯman</w>
                      <w xml:id="wid_00375" join="right">sanawāt</w>
@@ -654,7 +653,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:now" type="featureSample">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -666,7 +665,7 @@
                      <w xml:id="wid_00389" join="right">da</w>
                      <pc type="ws" xml:id="id_pc_1076" join="right">-</pc>
                      <w xml:id="wid_00390" join="right">ssawwīn</w>
-                        <w ana="semLib:now" xml:id="wid_00391" join="right">hassa</w>
+                        <w ana="semlib:now" xml:id="wid_00391" join="right">hassa</w>
                      <pc type="ws" xml:id="id_pc_1080" join="right">?</pc>
                      <w xml:id="wid_00392" join="right">–</w>
                      <w xml:id="wid_00393" join="right">ʔašūf</w>
@@ -693,7 +692,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:today" type="featureSample">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -701,7 +700,7 @@
                      <w xml:id="wid_00412" join="right">ǝǧ</w>
                      <pc type="ws" xml:id="id_pc_1134" join="right">-</pc>
                      <w xml:id="wid_00413" join="right">ǧaww</w>
-                     <phr ana="semLib:today">
+                     <phr ana="semlib:today">
                         <w xml:id="wid_00414" join="right">ǝl</w>
                         <pc type="ws" xml:id="id_pc_1138" join="right">-</pc>
                         <w xml:id="wid_00415">yōm</w>
@@ -722,12 +721,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:yesterday" type="featureSample">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <phr ana="semLib:yesterday">
+                     <phr ana="semlib:yesterday">
                         <w xml:id="wid_00427" join="right">ǝl</w>
                         <pc type="ws" xml:id="id_pc_1173" join="right">-</pc>
                         <w xml:id="wid_00428">bārḥa</w>
@@ -750,7 +749,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:tomorrow" type="featureSample">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -758,7 +757,7 @@
                      <w xml:id="wid_00442" join="right">ya</w>
                      <w xml:id="wid_00443" join="right">šabāb</w>
                      <pc type="ws" xml:id="id_pc_1213" join="right">,</pc>
-                        <w ana="semLib:tomorrow" xml:id="wid_00444" join="right">bāčǝr</w>
+                        <w ana="semlib:tomorrow" xml:id="wid_00444" join="right">bāčǝr</w>
                      <w xml:id="wid_00445" join="right">lāzim</w>
                      <w xml:id="wid_00446" join="right">ǝddursūn</w>
                      <pc type="ws" xml:id="id_pc_1220">.</pc>
@@ -776,12 +775,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:last_year" type="featureSample">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <phr ana="semLib:last_year">
+                     <phr ana="semlib:last_year">
                         <w xml:id="wid_00458" join="right">s</w>
                         <pc type="ws" xml:id="id_pc_1255" join="right">-</pc>
                         <w xml:id="wid_00459" join="right">sana</w>
@@ -820,7 +819,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit ana="vtLex:eight" type="featureSample">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -828,7 +827,7 @@
                      <w xml:id="wid_00483" join="right">ǝḥna</w>
                      <w xml:id="wid_00484" join="right">hnāya</w>
                      <w xml:id="wid_00485" join="right">mǝn</w>
-                        <w ana="semLib:eight" xml:id="wid_00486" join="right">ǝṯman</w>
+                        <w ana="semlib:eight" xml:id="wid_00486" join="right">ǝṯman</w>
                      <w xml:id="wid_00487" join="right">sanawāt</w>
                      <pc type="ws" xml:id="id_pc_1331">.</pc>
                   </quote>
@@ -845,7 +844,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:eleven" type="featureSample">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -861,7 +860,7 @@
                      <w xml:id="wid_00505" join="right">ǝs</w>
                      <pc type="ws" xml:id="id_pc_1376" join="right">-</pc>
                      <w xml:id="wid_00506" join="right">sāʕa</w>
-                        <w ana="semLib:eleven" xml:id="wid_00507" join="right">daʕaš</w>
+                        <w ana="semlib:eleven" xml:id="wid_00507" join="right">daʕaš</w>
                      <pc type="ws" xml:id="id_pc_1380">.</pc>
                   </quote>
                </cit>
@@ -881,13 +880,13 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:twelve" type="featureSample">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00521" join="right">ʕǝdhum</w>
-                        <w ana="semLib:twelve" xml:id="wid_00522" join="right">ǝṯnaʕaš</w>
+                        <w ana="semlib:twelve" xml:id="wid_00522" join="right">ǝṯnaʕaš</w>
                      <w xml:id="wid_00523" join="right">ṣaxla</w>
                      <w xml:id="wid_00524" join="right">/</w>
                      <w xml:id="wid_00525" join="right">maʕza</w>
@@ -910,7 +909,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:eighteen" type="featureSample">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -918,7 +917,7 @@
                      <w xml:id="wid_00539" join="right">ǝb</w>
                      <pc type="ws" xml:id="id_pc_1461" join="right">-</pc>
                      <w xml:id="wid_00540" join="right">ṣaffna</w>
-                        <w ana="semLib:eighteen" xml:id="wid_00541" join="right">ṯmunṭaʕaš</w>
+                        <w ana="semlib:eighteen" xml:id="wid_00541" join="right">ṯmunṭaʕaš</w>
                      <w xml:id="wid_00542" join="right">ṭālib</w>
                      <w xml:id="wid_00543" join="right">ǝǧdīd</w>
                      <pc type="ws" xml:id="id_pc_1469">.</pc>
@@ -940,7 +939,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit ana="vtLex:good" type="featureSample">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -950,7 +949,7 @@
                      <w xml:id="wid_00558" join="right">ǝšlōnǝč</w>
                      <pc type="ws" xml:id="id_pc_1517" join="right">?</pc>
                      <w xml:id="wid_00559" join="right">–</w>
-                        <w ana="semLib:good" xml:id="wid_00560" join="right">zēn</w>
+                        <w ana="semlib:good" xml:id="wid_00560" join="right">zēn</w>
                      <w xml:id="wid_00561" join="right">/</w>
                         <w xml:id="wid_00562" join="right">zēna</w>
                      <pc type="ws" xml:id="id_pc_1526" join="right">,</pc>
@@ -982,7 +981,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit ana="vtLex:white" type="featureSample">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -990,8 +989,8 @@
                   <quote xml:lang="ar">
                      <w xml:id="wid_00581" join="right">yǝlbas</w>
                      <w xml:id="wid_00582" join="right">raǧli</w>
-                     <w ana="semLib:shirt" xml:id="wid_00583" join="right">qamīṣ</w>
-                        <w ana="semLib:white" xml:id="wid_00584" join="right">ʔabyað̣</w>
+                     <w ana="semlib:shirt" xml:id="wid_00583" join="right">qamīṣ</w>
+                        <w ana="semlib:white" xml:id="wid_00584" join="right">ʔabyað̣</w>
                      <w xml:id="wid_00585" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_1595" join="right">-</pc>
                      <w xml:id="wid_00586" join="right">ʔāni</w>
@@ -1019,7 +1018,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:black" type="featureSample">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -1032,7 +1031,7 @@
                      <w xml:id="wid_00614" join="right">qamīṣ</w>
                      <w xml:id="wid_00615" join="right">ǝl</w>
                      <pc type="ws" xml:id="id_pc_1663" join="right">-</pc>
-                        <w ana="semLib:black" xml:id="wid_00616" join="right">ʔaswad</w>
+                        <w ana="semlib:black" xml:id="wid_00616" join="right">ʔaswad</w>
                      <pc type="ws" xml:id="id_pc_1665" join="right">.</pc>
                      <w xml:id="wid_00617" join="right">/</w>
                      <w xml:id="wid_00618" join="right">ma</w>
@@ -1059,7 +1058,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:pink" type="featureSample">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -1067,7 +1066,7 @@
                      <w xml:id="wid_00641" join="right">ǝštarat</w>
                      <w xml:id="wid_00642" join="right">marti</w>
                      <w xml:id="wid_00643" join="right">qamīṣ</w>
-                        <w ana="semLib:pink" xml:id="wid_00644" join="right">wardi</w>
+                        <w ana="semlib:pink" xml:id="wid_00644" join="right">wardi</w>
                      <w xml:id="wid_00645" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_1732" join="right">-</pc>
                      <w xml:id="wid_00646" join="right">ǧunṭa</w>
@@ -1090,13 +1089,13 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:grey" type="featureSample">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00663" join="right">ḥāyǝṭ</w>
-                        <w ana="semLib:grey" xml:id="wid_00664" join="right">rumādi</w>
+                        <w ana="semlib:grey" xml:id="wid_00664" join="right">rumādi</w>
                      <pc type="ws" xml:id="id_pc_1779" join="right">(</pc>
                         <w xml:id="wid_00665" join="right">riṣāṣi</w>
                      <pc type="ws" xml:id="id_pc_1781" join="right">)</pc>
@@ -1117,13 +1116,13 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:orange" type="featureSample">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00678" join="right">qamīṣ</w>
-                        <w ana="semLib:orange" xml:id="wid_00679" join="right">burtuqāli</w>
+                        <w ana="semlib:orange" xml:id="wid_00679" join="right">burtuqāli</w>
                      <w xml:id="wid_00680" join="right">/</w>
                      <w xml:id="wid_00681" join="right">siyyāra</w>
                         <w xml:id="wid_00682">burtuqālīya</w>
@@ -1140,14 +1139,14 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit ana="semLib:in" type="featureSample">
+            <cit ana="semlib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w ana="semLib:in" xml:id="wid_00691" join="right">ǝb</w>
+                     <w ana="semlib:in" xml:id="wid_00691" join="right">ǝb</w>
                      <pc type="ws" xml:id="id_pc_1859" join="right">-</pc>
                      <w xml:id="wid_00692" join="right">ṣaffna</w>
                         <w xml:id="wid_00693" join="right">ṯmunṭaʕaš</w>
@@ -1172,7 +1171,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit ana="vtLex:to_do" type="featureSample">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -1181,7 +1180,7 @@
                      <pc type="ws" xml:id="id_pc_1911" join="right">,</pc>
                      <w xml:id="wid_00709" join="right">ǝš</w>
                      <pc type="ws" xml:id="id_pc_1914" join="right">-</pc>
-                     <phr ana="semLib:to_do">
+                     <phr ana="semlib:to_do">
                         <w xml:id="wid_00710" join="right">da</w>
                         <pc type="ws" xml:id="id_pc_1916" join="right">-</pc>
                         <w xml:id="wid_00711">ssawwīn</w>
@@ -1213,12 +1212,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_stay" type="featureSample">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:to_stay" xml:id="wid_00733" join="right">ubqa</w>
+                        <w ana="semlib:to_stay" xml:id="wid_00733" join="right">ubqa</w>
                      <pc type="ws" xml:id="id_pc_1976" join="right">(</pc>
                      <w xml:id="wid_00734" join="right">m</w>
                      <pc type="ws" xml:id="id_pc_1978" join="right">.</pc>
@@ -1263,12 +1262,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_speak" type="featureSample">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:to_speak" xml:id="wid_00763" join="right">tǝḥči</w>
+                        <w ana="semlib:to_speak" xml:id="wid_00763" join="right">tǝḥči</w>
                      <w xml:id="wid_00764" join="right">ʕarabi</w>
                      <pc type="ws" xml:id="id_pc_2060" join="right">?</pc>
                      <w xml:id="wid_00765" join="right">–</w>
@@ -1291,7 +1290,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_rain" type="featureSample">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -1299,7 +1298,7 @@
                      <w xml:id="wid_00780" join="right">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2102" join="right">-</pc>
                      <w xml:id="wid_00781" join="right">bārḥa</w>
-                     <phr ana="semLib:to_rain">
+                     <phr ana="semlib:to_rain">
                         <w xml:id="wid_00782" join="right">čānat</w>
                         
                         <w xml:id="wid_00783">ǝtmaṭṭǝr</w>
@@ -1320,15 +1319,15 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_open" type="featureSample">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:to_open" xml:id="wid_00791" join="right">ǝftaḥ</w>
+                        <w ana="semlib:to_open" xml:id="wid_00791" join="right">ǝftaḥ</w>
                      <w xml:id="wid_00792" join="right">ǝš</w>
                      <pc type="ws" xml:id="id_pc_2135" join="right">-</pc>
-                     <w ana="semLib:window" xml:id="wid_00793" join="right">šubbāk</w>
+                     <w ana="semlib:window" xml:id="wid_00793" join="right">šubbāk</w>
                      <pc type="ws" xml:id="id_pc_2137">!</pc>
                   </quote>
                </cit>
@@ -1342,12 +1341,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_close" type="featureSample">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:to_close" xml:id="wid_00800" join="right">sidd</w>
+                        <w ana="semlib:to_close" xml:id="wid_00800" join="right">sidd</w>
                      <w xml:id="wid_00801" join="right">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2162" join="right">-</pc>
                      <w xml:id="wid_00802" join="right">bībān</w>
@@ -1363,13 +1362,13 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_take" type="featureSample">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00808" join="right">šǝnu</w>
-                        <w ana="semLib:to_take" xml:id="wid_00809" join="right">ʔaxaḏti</w>
+                        <w ana="semlib:to_take" xml:id="wid_00809" join="right">ʔaxaḏti</w>
                      <w xml:id="wid_00810" join="right">wiyyāč</w>
                      <pc type="ws" xml:id="id_pc_2188" join="right">?</pc>
                      <w xml:id="wid_00811" join="right">/</w>
@@ -1396,19 +1395,19 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_give" type="featureSample">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:to_give" xml:id="wid_00830" join="right">ǝnṭēt</w>
+                        <w ana="semlib:to_give" xml:id="wid_00830" join="right">ǝnṭēt</w>
                      <w xml:id="wid_00831" join="right">/</w>
                         <w xml:id="wid_00832" join="right">ǝṭṭēt</w>
                      <w xml:id="wid_00833" join="right">Aḥmad</w>
                      <w xml:id="wid_00834" join="right">ǝr</w>
                      <pc type="ws" xml:id="id_pc_2250" join="right">-</pc>
-                     <w ana="semLib:letter" xml:id="wid_00835" join="right">risāla</w>
+                     <w ana="semlib:letter" xml:id="wid_00835" join="right">risāla</w>
                      <pc type="ws" xml:id="id_pc_2252" join="right">?</pc>
                      <w xml:id="wid_00836" join="right">–</w>
                      <w xml:id="wid_00837" join="right">ʔē</w>
@@ -1441,18 +1440,18 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_see" type="featureSample">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00862" join="right">ǝǧ</w>
                      <pc type="ws" xml:id="id_pc_2316" join="right">-</pc>
-                     <w ana="semLib:children" xml:id="wid_00863" join="right">ǧahhāl</w>
-                        <w ana="semLib:to_see" xml:id="wid_00864" join="right">šāfaw</w>
+                     <w ana="semlib:children" xml:id="wid_00863" join="right">ǧahhāl</w>
+                        <w ana="semlib:to_see" xml:id="wid_00864" join="right">šāfaw</w>
                      <w xml:id="wid_00865" join="right">imǧaddi</w>
                      <w xml:id="wid_00866" join="right">wara</w>
-                     <w ana="semLib:house" xml:id="wid_00867" join="right">bēt</w>
+                     <w ana="semlib:house" xml:id="wid_00867" join="right">bēt</w>
                      <w xml:id="wid_00867a" join="right">na</w>
                      <pc type="ws" xml:id="id_pc_2326">.</pc>
                   </quote>
@@ -1471,7 +1470,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_want" type="featureSample">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
@@ -1479,17 +1478,17 @@
                   <quote xml:lang="ar">
                      <w xml:id="wid_00881" join="right">ši</w>
                      <pc type="ws" xml:id="id_pc_2363" join="right">-</pc>
-                        <w ana="semLib:to_want" xml:id="wid_00882" join="right">trīd</w>
+                        <w ana="semlib:to_want" xml:id="wid_00882" join="right">trīd</w>
                      <w xml:id="wid_00883" join="right">tišrab</w>
-                     <w ana="semLib:coffee #vt_phon_CA_q" xml:id="wid_00884" join="right">gahwa</w>
+                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00884" join="right">gahwa</w>
                      <w xml:id="wid_00885" join="right">lō</w>
-                     <w ana="semLib:tea" xml:id="wid_00886" join="right">čāy</w>
+                     <w ana="semlib:tea" xml:id="wid_00886" join="right">čāy</w>
                      <pc type="ws" xml:id="id_pc_2373" join="right">?</pc>
                      <w xml:id="wid_00887" join="right">–</w>
                         <w xml:id="wid_00888" join="right">ʔarīd</w>
                      <w xml:id="wid_00889" join="right">čāy</w>
                      <pc type="ws" xml:id="id_pc_2380" join="right">,</pc>
-                     <phr ana="semLib:please">
+                     <phr ana="semlib:please">
                      
                         <w xml:id="wid_00890" join="right">aḷḷa</w>
                      
@@ -1514,7 +1513,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_bring" type="featureSample">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
@@ -1524,7 +1523,7 @@
                      <w xml:id="wid_00912" join="right">yxallīk</w>
                      <pc type="ws" xml:id="id_pc_2438" join="right">,</pc>
                      <w xml:id="wid_00913" join="right">balki</w>
-                        <w ana="semLib:to_bring" xml:id="wid_00914" join="right">tǧīb</w>
+                        <w ana="semlib:to_bring" xml:id="wid_00914" join="right">tǧīb</w>
                      <pc type="ws" xml:id="id_pc_2443" join="right">-</pc>
                      <w xml:id="wid_00915" join="right">li</w>
                      <w xml:id="wid_00916" join="right">š</w>
@@ -1559,15 +1558,15 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:to_have" type="featureSample">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semLib:to_have" xml:id="wid_00941" join="right">ʕǝd</w>
+                        <w ana="semlib:to_have" xml:id="wid_00941" join="right">ʕǝd</w>
                      <w xml:id="wid_00942" join="right">hum</w>
-                     <w ana="semLib:much" xml:id="wid_00943" join="right">ǝhwāya</w>
-                     <w ana="semLib:money" xml:id="wid_00944" join="right">flūs</w>
+                     <w ana="semlib:much" xml:id="wid_00943" join="right">ǝhwāya</w>
+                     <w ana="semlib:money" xml:id="wid_00944" join="right">flūs</w>
                      <w xml:id="wid_00945" join="right">bass</w>
                      <w xml:id="wid_00946" join="right">humma</w>
                      <w xml:id="wid_00947" join="right">mū</w>
@@ -1595,7 +1594,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit ana="semLib:since_for" type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
@@ -1605,7 +1604,7 @@
                   <quote xml:lang="ar">
                      <w xml:id="wid_00966" join="right">ǝḥna</w>
                      <w xml:id="wid_00967" join="right">hnāya</w>
-                        <w ana="semLib:since_for" xml:id="wid_00968" join="right">mǝn</w>
+                        <w ana="semlib:since_for" xml:id="wid_00968" join="right">mǝn</w>
                      <w xml:id="wid_00969" join="right">ǝṯman</w>
                      <w xml:id="wid_00970" join="right">sanawāt</w>
                      <pc type="ws" xml:id="id_pc_2586">.</pc>
@@ -1626,7 +1625,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit ana="vtLex:women" type="featureSample">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
@@ -1641,7 +1640,7 @@
                      <w xml:id="wid_00986" join="right">haḏōlāk</w>
                         <w xml:id="wid_00987" join="right">in</w>
                         <pc type="ws" xml:id="id_pc_2639" join="right">-</pc>
-                        <w ana="semLib:women" xml:id="wid_00988" join="right">nǝswān</w>
+                        <w ana="semlib:women" xml:id="wid_00988" join="right">nǝswān</w>
                      <pc type="ws" xml:id="id_pc_2641" join="right">?</pc>
                      <w xml:id="wid_00989" join="right">–</w>
                      <w xml:id="wid_00990" join="right">gāʕǝd</w>
@@ -1674,14 +1673,14 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:husband" type="featureSample">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_01016" join="right">yǝlbas</w>
-                        <w ana="semLib:husband" xml:id="wid_01017" join="right">raǧl</w>
+                        <w ana="semlib:husband" xml:id="wid_01017" join="right">raǧl</w>
                      <w xml:id="id_w_0" join="right">i</w>
                      <w xml:id="wid_01018" join="right">qamīṣ</w>
                      <w xml:id="wid_01019" join="right">ʔabyað̣</w>
@@ -1712,7 +1711,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:friend" type="featureSample">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -1725,7 +1724,7 @@
                      <pc type="ws" xml:id="id_pc_2780" join="right">?</pc>
                      <w xml:id="wid_01049" join="right">–</w>
                      <w xml:id="wid_01050" join="right">huwwa</w>
-                        <w ana="semLib:friend" xml:id="wid_01051" join="right">ṣadīq</w>
+                        <w ana="semlib:friend" xml:id="wid_01051" join="right">ṣadīq</w>
                      <w xml:id="wid_01052" join="right">i</w>
                      <pc type="ws" xml:id="id_pc_2788">.</pc>
                   </quote>
@@ -1749,7 +1748,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit ana="semLib:mobile" type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1757,7 +1756,7 @@
                      <w xml:id="wid_01067" join="right">wēn</w>
                      <w xml:id="wid_01068" join="right">ǝl</w>
                      <pc type="ws" xml:id="id_pc_2839" join="right">-</pc>
-                        <w ana="semLib:mobile" xml:id="wid_01069" join="right">mōbāyl</w>
+                        <w ana="semlib:mobile" xml:id="wid_01069" join="right">mōbāyl</w>
                      <w xml:id="wid_01070" join="right">mālti</w>
                      <pc type="ws" xml:id="id_pc_2843" join="right">?</pc>
                      <w xml:id="wid_01071" join="right">–</w>
@@ -1783,12 +1782,12 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit ana="vtLex:being_unable" type="featureSample">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <phr ana="semLib:being_unable">
+                     <phr ana="semlib:being_unable">
                         <w xml:id="wid_01086" join="right">ma</w>
                      
                      
@@ -1814,7 +1813,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:ability" type="featureSample">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play domino? – Yes.</quote>
                <cit type="translation">
@@ -1843,7 +1842,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="vtLex:possibility" type="featureSample">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1862,7 +1861,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit ana="vtLex:a_little" type="featureSample">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1872,7 +1871,7 @@
                      <pc type="ws" xml:id="id_pc_3011" join="right">?</pc>
                      <w xml:id="wid_01124" join="right">–</w>
                      <w xml:id="wid_01125" join="right">bass</w>
-                        <w ana="semLib:a_little" xml:id="wid_01126" join="right">ǝšwayya</w>
+                        <w ana="semlib:a_little" xml:id="wid_01126" join="right">ǝšwayya</w>
                      <pc type="ws" xml:id="id_pc_3018">.</pc>
                   </quote>
                </cit>
@@ -1917,7 +1916,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="fvLib:pres_f_sg" type="featureSample">
+            <cit ana="fvlib:pres_f_sg" type="featureSample">
                <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">
@@ -1926,7 +1925,7 @@
                      <w xml:id="wid_01157" join="right">ǝl</w>
                      <pc type="ws" xml:id="id_pc_3097" join="right">-</pc>
                      <w xml:id="wid_01158" join="right">mōbāyl</w>
-                        <w ana="fvLib:pres_f_sg" xml:id="wid_01159" join="right">mālt</w>
+                        <w ana="fvlib:pres_f_sg" xml:id="wid_01159" join="right">mālt</w>
                      <w xml:id="wid_01160" join="right">i</w>
                      <pc type="ws" xml:id="id_pc_3102" join="right">?</pc>
                      <w xml:id="wid_01161" join="right">–</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -555,7 +555,7 @@
          </div>
          <div type="featureGroup">
             <head>Pronouns</head>
-            <cit type="featureSample">
+            <cit type="featureSample" ana="fvlib:perspron_1_sg">
                <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
@@ -373,7 +373,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit type="featureSample" ana="fvlib:dempron_prox_m_sg">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -382,7 +382,7 @@
                      <w xml:id="id_245" join="right">iṛ</w>
                      <pc type="ws" xml:id="id_246" join="right">-</pc>
                      <w xml:id="id_247">ṛāgil</w>
-                        <w xml:id="id_249">da</w>
+                     <w xml:id="id_249" ana="fvlib:dempron_prox_m_sg">da</w>
                      <pc type="ws" xml:id="id_250">?</pc>
                      <w xml:id="id_252">–</w>
                      <w xml:id="id_254">da</w>
@@ -401,12 +401,12 @@
          </div>
          <div type="featureGroup">
             <head>Pronouns</head>
-            <cit type="featureSample">
+            <cit type="featureSample" ana="fvlib:perspron_1_sg">
                <lbl xml:space="preserve">I</lbl>
                <quote xml:lang="en">I am a teacher.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w xml:id="id_263">ʔana</w>
+                        <w xml:id="id_263" ana="fvlib:perspron_1_sg">ʔana</w>
                       <w xml:id="id_264" join="right">mudarris</w>
                      <pc type="ws" xml:id="id_265">.</pc>
                   </quote>
@@ -415,23 +415,9 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
-               <lbl xml:space="preserve">
-                  <hi rend="bold">Presentatives</hi>
-               </lbl>
-               <quote xml:lang="en"/>
-               <cit type="translation">
-                  <quote xml:lang="ar"/>
-               </cit>
-               <cit type="translation">
-                  <quote xml:lang="de">
-                     <pc type="ws" xml:id="id_266" join="right">?</pc>
-                     <pc type="ws" xml:id="id_267" join="right">?</pc>
-                     <pc type="ws" xml:id="id_268" join="right">?</pc>
-                     <pc type="ws" xml:id="id_269">?</pc>
-                  </quote>
-               </cit>
-            </cit>
+           </div>
+         <div type="featureGroup">
+            <head>Presentatives</head>
             <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p>
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -45,7 +40,7 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
@@ -73,7 +68,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
@@ -103,7 +98,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -129,7 +124,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -157,7 +152,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
@@ -180,7 +175,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -207,7 +202,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Cairo.</quote>
@@ -233,7 +228,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -257,7 +252,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -299,7 +294,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_much" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
@@ -325,7 +320,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
@@ -351,7 +346,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
@@ -437,7 +432,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
@@ -465,7 +460,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="fvlib:pres_f_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
@@ -492,7 +487,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="semlib:here">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -510,7 +505,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:now">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -536,7 +531,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:today">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -554,7 +549,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:yesterday">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -572,7 +567,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:tomorrow">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -591,7 +586,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:last_year">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -619,7 +614,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="semlib:eight">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -637,7 +632,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eleven">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -659,7 +654,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:twelve">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -672,7 +667,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eighteen">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -693,7 +688,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="semlib:good">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -736,7 +731,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="semlib:white">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -757,7 +752,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:black">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -788,7 +783,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:pink">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -817,7 +812,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:grey">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall/a grey bag</quote>
                <cit type="translation">
@@ -838,7 +833,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:orange">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt/car</quote>
                <cit type="translation">
@@ -861,7 +856,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semlib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -884,7 +879,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="semlib:to_do">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -910,7 +905,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_stay">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -934,7 +929,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_speak">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -951,7 +946,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_rain">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -969,7 +964,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_open">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -985,7 +980,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_close">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -1001,7 +996,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_take">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1020,7 +1015,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_give">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
@@ -1049,7 +1044,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_see">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1079,7 +1074,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_want">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
@@ -1106,7 +1101,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_bring">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
                      you.</quote>
@@ -1124,7 +1119,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_have">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1144,7 +1139,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects 
                      use periphrastic constructions to render 
@@ -1171,7 +1166,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="semlib:women">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking 
                      bread.</quote>
@@ -1193,7 +1188,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:husband">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1215,7 +1210,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:friend">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -1244,7 +1239,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1267,7 +1262,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="semlib:being_unable">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1284,7 +1279,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:ability">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play chess? – Yes.</quote>
                <cit type="translation">
@@ -1300,7 +1295,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:possibility">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1318,7 +1313,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="semlib:a_little">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1336,7 +1331,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:existential" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -1354,7 +1349,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:gen_explicative" type="featureSample">
                <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p xml:id="id_p_12">
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -45,7 +40,7 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
@@ -71,7 +66,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
@@ -98,7 +93,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -127,7 +122,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">Often reflexes reflexes of CA <hi rend="italic">li + ’ayy
                      </hi>or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -148,7 +143,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">Often reflexes of CA <hi rend="italic">fī + ’ayna</hi>
                   </note>
@@ -173,7 +168,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -196,7 +191,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Aleppo.</quote>
@@ -225,7 +220,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -247,7 +242,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -271,7 +266,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_much" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Lira. </quote>
                <cit type="translation">
@@ -295,7 +290,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
@@ -320,7 +315,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Abu
                      Rammana. </quote>
@@ -349,7 +344,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -410,7 +405,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">here is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
@@ -444,7 +439,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="fvlib:pres_f_sg" type="featureSample">
                <lbl xml:space="preserve">here is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
@@ -472,7 +467,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="semlib:here">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -490,7 +485,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:now">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -519,7 +514,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:today">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -540,7 +535,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:yesterday">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -564,7 +559,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:tomorrow">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -582,7 +577,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:last_year">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -602,7 +597,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="semlib:eight">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -620,7 +615,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eleven">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -642,7 +637,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:twelve">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -660,7 +655,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eighteen">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -682,7 +677,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="semlib:good">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -708,7 +703,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="semlib:white">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -729,7 +724,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:black">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. /car</quote>
                <cit type="translation">
@@ -771,7 +766,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:pink">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -797,7 +792,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:grey">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall/a grey bag</quote>
                <cit type="translation">
@@ -820,7 +815,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:orange">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt/car</quote>
                <cit type="translation">
@@ -839,7 +834,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semlib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -863,7 +858,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="semlib:to_do">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -892,7 +887,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_stay">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -914,7 +909,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_speak">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -932,7 +927,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_rain">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -959,7 +954,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_open">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -975,7 +970,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_close">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -991,7 +986,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_take">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1011,7 +1006,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_give">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
@@ -1038,7 +1033,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_see">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1058,7 +1053,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_want">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea 
                      please.</quote>
@@ -1086,7 +1081,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_bring">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
                      you.</quote>
@@ -1119,7 +1114,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_have">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1146,7 +1141,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
@@ -1173,7 +1168,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="semlib:women">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? –
                      They are baking bread.</quote>
@@ -1199,7 +1194,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:husband">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1221,7 +1216,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:friend">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -1250,7 +1245,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1276,7 +1271,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="semlib:being_unable">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1297,7 +1292,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:ability">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play barsīs? – Yes.</quote>
                <cit type="translation">
@@ -1321,7 +1316,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:possibility">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1340,7 +1335,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="semlib:a_little">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1358,7 +1353,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:existential" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -1377,7 +1372,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:gen_explicative" type="featureSample">
                <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
@@ -387,24 +387,9 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample">
-               <lbl xml:space="preserve">
-                  <hi rend="bold">Presentatives</hi>
-               </lbl>
-               <quote xml:lang="en"/>
-               <cit type="translation">
-                  <quote xml:lang="ar"/>
-               </cit>
-               <cit type="translation">
-                  <quote xml:lang="de">
-                     <pc type="ws" xml:id="id_pc_410" join="right">(</pc>
-                     <pc type="ws" xml:id="id_pc_411" join="right">?</pc>
-                     <pc type="ws" xml:id="id_pc_412" join="right">?</pc>
-                     <pc type="ws" xml:id="id_pc_413" join="right">?</pc>
-                     <pc type="ws" xml:id="id_pc_414">)</pc>
-                  </quote>
-               </cit>
-            </cit>
+            </div>
+         <div type="featureGroup">
+            <head>Presentatives</head>
             <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">here is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>

--- a/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
@@ -599,7 +599,7 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit type="featureSample">
+            <cit type="featureSample" ana="fvlib:pres_m_sg">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
@@ -611,9 +611,11 @@
                      <w xml:id="id_879" join="right">tālīfūni</w>
                      <pc type="ws" xml:id="id_880">?</pc>
                      <w xml:id="id_882">–</w>
+                     <phr ana="fvlib:pres_m_sg">
                      <w xml:id="id_884">hāw</w>
                         <w xml:id="id_886">ǝhnē</w>
                      <pc type="ws" xml:id="id_887">.</pc>
+                     </phr>
                   </quote>
                </cit>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p xml:id="id_p_12">
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -46,7 +41,7 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
@@ -81,7 +76,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
@@ -126,7 +121,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -164,7 +159,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -204,7 +199,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
@@ -239,7 +234,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -287,7 +282,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      ….</quote>
@@ -333,7 +328,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -374,7 +369,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -416,7 +411,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_much" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
@@ -457,7 +452,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
@@ -507,7 +502,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in ... </quote>
                <cit type="translation">
@@ -551,7 +546,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -660,7 +655,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="semlib:here">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -684,7 +679,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:now">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -722,7 +717,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:today">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -754,7 +749,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:yesterday">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -776,7 +771,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:tomorrow">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -802,7 +797,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:last_year">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -839,7 +834,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="semlib:eight">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -863,7 +858,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eleven">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -896,7 +891,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:twelve">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -928,7 +923,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eighteen">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -959,7 +954,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="semlib:good">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -1007,7 +1002,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="semlib:white">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1044,7 +1039,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:black">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -1092,7 +1087,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:pink">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -1125,7 +1120,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:grey">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
@@ -1154,7 +1149,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:orange">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
@@ -1179,7 +1174,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semlib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -1212,7 +1207,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="semlib:to_do">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -1250,7 +1245,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_stay">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -1286,7 +1281,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_speak">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1318,7 +1313,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_rain">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -1343,7 +1338,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_open">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -1365,7 +1360,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_close">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -1386,7 +1381,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_take">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1412,7 +1407,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_give">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
@@ -1456,7 +1451,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_see">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1489,7 +1484,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_want">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
@@ -1528,7 +1523,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_bring">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
@@ -1580,7 +1575,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_have">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1615,7 +1610,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
@@ -1646,7 +1641,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="semlib:women">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
@@ -1686,7 +1681,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:husband">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1710,7 +1705,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:friend">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -1746,7 +1741,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1783,7 +1778,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="semlib:being_unable">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1814,7 +1809,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:ability">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play chess/domino? –
                      Yes.</quote>
@@ -1858,7 +1853,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:possibility">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1877,7 +1872,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="semlib:a_little">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1909,7 +1904,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:existential" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -22,18 +22,19 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
-            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
+            <prefixDef matchPattern="(.+)"
+               replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib" />
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib" />
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
 
-    <text>
+   <text>
       <body>
          <head>
-              <name xml:lang="eng" type="city">Tunis</name>
-              <name xml:lang="eng" type="country">Tunisia</name>
-          </head>
+            <name xml:lang="eng" type="city">Tunis</name>
+            <name xml:lang="eng" type="country">Tunisia</name>
+         </head>
          <div type="positioning">
             <p xml:id="id_p_24">
                <geo>36.8, 10.18</geo>
@@ -47,7 +48,7 @@
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:who" xml:id="wid_00000">škūn</w>
+                     <w ana="semlib:who" xml:id="wid_00000">škūn</w>
                      <w xml:id="wid_00001" join="right">hā</w>
                      <pc type="ws" xml:id="id_pc_46" join="right">-</pc>
                      <w xml:id="wid_00002" join="right">ṛ</w>
@@ -78,13 +79,12 @@
             </cit>
             <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
-               <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
-                     good.</quote>
+               <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s good.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w ana="fvlib:dempron_prox_f_sg" xml:id="wid_00021">hāḏi</w>
                      <w ana="semlib:car" xml:id="wid_00022">kaṛhabt</w>
-                        <w ana="semlib:whose" xml:id="wid_00023">əškūn</w>
+                     <w ana="semlib:whose" xml:id="wid_00023">əškūn</w>
                      <pc type="ws" xml:id="id_pc_101">?</pc>
                      <w xml:id="wid_00024">–</w>
                      <w xml:id="wid_00025">hāḏi</w>
@@ -137,7 +137,7 @@
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:what" xml:id="wid_00063">āš/š</w>
+                     <w ana="semlib:what" xml:id="wid_00063">āš/š</w>
                      <pc type="ws" xml:id="id_pc_198" join="right">-</pc>
                      <w xml:id="wid_00064">ʕāmla</w>
                      <w xml:id="wid_00065" join="right">taww</w>
@@ -177,9 +177,7 @@
             </cit>
             <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
-               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
-                        + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
-                  </note>
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi></note>
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -218,13 +216,11 @@
             </cit>
             <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
-               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
-                        + ’ayna</hi>
-                  </note>
+               <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī + ’ayna</hi></note>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:where" xml:id="wid_00113">wīn</w>
+                     <w ana="semlib:where" xml:id="wid_00113">wīn</w>
                      <w xml:id="wid_00114" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_330" join="right">-</pc>
                      <w xml:id="wid_00115">buṛṭābil</w>
@@ -262,7 +258,7 @@
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:where_to" xml:id="wid_00136">wīn</w>
+                     <w ana="semlib:where_to" xml:id="wid_00136">wīn</w>
                      <w xml:id="wid_00137">māši</w>
                      <w xml:id="wid_00138">/</w>
                      <w xml:id="wid_00139" join="right">māšya</w>
@@ -299,12 +295,12 @@
             </cit>
             <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
-               <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
-                     ….</quote>
+               <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from….</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:where_from" xml:id="wid_00163">mnīn</w>
-                     <w ana="fvlib:perspron_2_sg_m fvlib:perspron_2_sg_f" xml:id="wid_00164">inti</w>
+                     <w ana="semlib:where_from" xml:id="wid_00163">mnīn</w>
+                     <w ana="fvlib:perspron_2_sg_m fvlib:perspron_2_sg_f" xml:id="wid_00164"
+                        >inti</w>
                      <w xml:id="wid_00165">/</w>
                      <w ana="fvlib:perspron_2_pl" xml:id="wid_00166" join="right">intūma</w>
                      <pc type="ws" xml:id="id_pc_466">?</pc>
@@ -339,10 +335,10 @@
             </cit>
             <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
-               <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
+               <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:when" xml:id="wid_00196">waqtāš</w>
+                     <w ana="semlib:when" xml:id="wid_00196">waqtāš</w>
                      <w xml:id="wid_00197">rīt/šuft</w>
                      <w xml:id="wid_00198" join="right">Muḥammad</w>
                      <pc type="ws" xml:id="id_pc_544">,</pc>
@@ -384,15 +380,9 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <phr ana="semlib:how">
-                     
                         <w xml:id="wid_00226">šnūwa</w>
-                     
-                     
                         <w xml:id="wid_00227">/</w>
-                     
-                     
                         <w xml:id="wid_00228">šnīye</w>
-                     
                      </phr>
                      <w xml:id="wid_00229" join="right">ḥwālik</w>
                      <pc type="ws" xml:id="id_pc_620">?</pc>
@@ -430,7 +420,7 @@
                         <w xml:id="wid_00249" join="right">b</w>
                         <pc type="ws" xml:id="id_pc_673" join="right">-</pc>
                         <w xml:id="wid_00250">qaddāš</w>
-                        </phr>
+                     </phr>
                      <w xml:id="wid_00251">əṛṭal</w>
                      <w ana="semlib:lemon" xml:id="wid_00252" join="right">līmūn</w>
                      <pc type="ws" xml:id="id_pc_679" join="right">?</pc>
@@ -458,12 +448,10 @@
             </cit>
             <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
-               <quote xml:lang="en">How many children do you (f.) have? – I have
-                     two daughters
-                     and three sons.</quote>
+               <quote xml:lang="en">How many children do you (f.) have? – I have two daughters andthree sons.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:how_many" xml:id="wid_00270">qaddāš</w>
+                     <w ana="semlib:how_many" xml:id="wid_00270">qaddāš</w>
                      <w xml:id="wid_00271">ʕandik</w>
                      <w xml:id="wid_00272" join="right">ūlād</w>
                      <pc type="ws" xml:id="id_pc_735">?</pc>
@@ -507,12 +495,12 @@
                   <quote xml:lang="ar">
                      <w xml:id="wid_00300" join="right">f</w>
                      <pc type="ws" xml:id="id_pc_802" join="right">-</pc>
-                        <w ana="semlib:which" xml:id="wid_00301">āni</w>
+                     <w ana="semlib:which" xml:id="wid_00301">āni</w>
                      <w xml:id="wid_00302">žīha</w>
                      <w xml:id="wid_00303">/</w>
                      <w xml:id="wid_00304" join="right">f</w>
                      <pc type="ws" xml:id="id_pc_810" join="right">-</pc>
-                        <w xml:id="wid_00305">ānu</w>
+                     <w xml:id="wid_00305">ānu</w>
                      <w xml:id="wid_00306">ḥayy</w>
                      <w xml:id="wid_00307" join="right">tusuknu</w>
                      <pc type="ws" xml:id="id_pc_816">?</pc>
@@ -549,7 +537,7 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00329">škūn</w>
-                        <w ana="fvlib:dempron_prox_m_sg" xml:id="wid_00330">hā</w>
+                     <w ana="fvlib:dempron_prox_m_sg" xml:id="wid_00330">hā</w>
                      <pc type="ws" xml:id="id_pc_883" join="right">-</pc>
                      <w xml:id="wid_00331" join="right">ṛ</w>
                      <pc type="ws" xml:id="id_pc_885" join="right">-</pc>
@@ -673,12 +661,8 @@
                      <w xml:id="wid_00383">ṯmānya</w>
                      <w xml:id="wid_00384">snīn</w>
                      <phr ana="semlib:here">
-                     
                         <w xml:id="wid_00385">hūni</w>
-                     
-                     
                         <w xml:id="wid_00386">/</w>
-                     
                         <w xml:id="wid_00387">əhnā</w>
                      </phr>
                      <pc type="ws" xml:id="id_pc_1065">.</pc>
@@ -705,12 +689,10 @@
                      <pc type="ws" xml:id="id_pc_1097" join="right">-</pc>
                      <w xml:id="wid_00400">ʕāmla</w>
                      <phr ana="semlib:now">
-                     
                         <w xml:id="wid_00401" join="right">taww</w>
                         <pc type="ws" xml:id="id_pc_1101" join="right">(</pc>
                         <w xml:id="wid_00402" join="right">a</w>
                         <pc type="ws" xml:id="id_pc_1103">)</pc>
-                     
                      </phr>
                      <pc type="ws" xml:id="id_pc_1104">,</pc>
                      <w xml:id="wid_00403">yā</w>
@@ -757,7 +739,7 @@
                         <w xml:id="wid_00430" join="right">l</w>
                         <pc type="ws" xml:id="id_pc_1173" join="right">-</pc>
                         <w xml:id="wid_00431">yūm</w>
-                        </phr>
+                     </phr>
                      <pc type="ws" xml:id="id_pc_1175">.</pc>
                   </quote>
                </cit>
@@ -778,15 +760,9 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <phr ana="semlib:yesterday">
-                     
                         <w xml:id="wid_00441">ilbāraḥ</w>
-                     
-                     
                         <w xml:id="wid_00442">/</w>
-                     
-                     
                         <w xml:id="wid_00443">imbāraḥ</w>
-                     
                      </phr>
                      <w xml:id="wid_00444">ṣabb</w>
                      <w xml:id="wid_00445" join="right">li</w>
@@ -811,7 +787,7 @@
                      <w xml:id="wid_00454">yā</w>
                      <w xml:id="wid_00455" join="right">ūlād</w>
                      <pc type="ws" xml:id="id_pc_1239">,</pc>
-                        <w ana="semlib:tomorrow" xml:id="wid_00456">ġudwa</w>
+                     <w ana="semlib:tomorrow" xml:id="wid_00456">ġudwa</w>
                      <w xml:id="wid_00457">yilzimkum</w>
                      <w xml:id="wid_00458" join="right">taqṛāu</w>
                      <pc type="ws" xml:id="id_pc_1246">.</pc>
@@ -838,13 +814,11 @@
                         <w xml:id="wid_00470" join="right">il</w>
                         <pc type="ws" xml:id="id_pc_1281" join="right">-</pc>
                         <w xml:id="wid_00471">ʕām</w>
-                        
                         <w xml:id="wid_00472">illi</w>
-                        
                         <w xml:id="wid_00473">fāt</w>
-                        </phr>
+                     </phr>
                      <w xml:id="wid_00474">/</w>
-                        <w xml:id="wid_00475">ʕāmnāwal</w>
+                     <w xml:id="wid_00475">ʕāmnāwal</w>
                      <w xml:id="wid_00476">kānit</w>
                      <w xml:id="wid_00477">ʕandna</w>
                      <w xml:id="wid_00478">/</w>
@@ -877,7 +851,7 @@
                      <w xml:id="wid_00494">ʕandna</w>
                      <w xml:id="wid_00495">/</w>
                      <w xml:id="wid_00496">ʕanna</w>
-                        <w ana="semlib:eight" xml:id="wid_00497">ṯmānya</w>
+                     <w ana="semlib:eight" xml:id="wid_00497">ṯmānya</w>
                      <w xml:id="wid_00498">snīn</w>
                      <w xml:id="wid_00499">hūni</w>
                      <w xml:id="wid_00500">/</w>
@@ -910,7 +884,7 @@
                      <w xml:id="wid_00516">–</w>
                      <w xml:id="wid_00517" join="right">la</w>
                      <pc type="ws" xml:id="id_pc_1402" join="right">-</pc>
-                        <w ana="semlib:eleven" xml:id="wid_00518">ḥdāš</w>
+                     <w ana="semlib:eleven" xml:id="wid_00518">ḥdāš</w>
                      <pc type="ws" xml:id="id_pc_1404">.</pc>
                   </quote>
                </cit>
@@ -936,9 +910,9 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00532">ʕandhum</w>
-                        <w ana="semlib:twelve" xml:id="wid_00533" join="right">ṯnāš</w>
-                        <pc type="ws" xml:id="id_pc_1443" join="right">-</pc>
-                        <w xml:id="wid_00534">in</w>
+                     <w ana="semlib:twelve" xml:id="wid_00533" join="right">ṯnāš</w>
+                     <pc type="ws" xml:id="id_pc_1443" join="right">-</pc>
+                     <w xml:id="wid_00534">in</w>
                      <w xml:id="wid_00535">miʕza</w>
                      <w xml:id="wid_00536" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_1449" join="right">-</pc>
@@ -968,10 +942,10 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00552">famma</w>
-                        <w ana="semlib:eighteen" xml:id="wid_00553" join="right">ṯmunṭāš</w>
-                        <pc type="ws" xml:id="id_pc_1491" join="right">-</pc>
-                        <w xml:id="wid_00554">in</w> 
-                        <w xml:id="wid_00555">ṭālib</w>
+                     <w ana="semlib:eighteen" xml:id="wid_00553" join="right">ṯmunṭāš</w>
+                     <pc type="ws" xml:id="id_pc_1491" join="right">-</pc>
+                     <w xml:id="wid_00554">in</w>
+                     <w xml:id="wid_00555">ṭālib</w>
                      <w xml:id="wid_00556">ždīd</w>
                      <w ana="semlib:in" xml:id="wid_00557" join="right">f</w>
                      <pc type="ws" xml:id="id_pc_1498" join="right">-</pc>
@@ -1011,9 +985,8 @@
                      <w xml:id="wid_00577">–</w>
                      <phr ana="semlib:good">
                         <w xml:id="wid_00578">lā</w>
-                        
                         <w xml:id="wid_00579">bās</w>
-                        </phr>
+                     </phr>
                      <pc type="ws" xml:id="id_pc_1561">.</pc>
                   </quote>
                </cit>
@@ -1041,14 +1014,13 @@
             <head>Colours</head>
             <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
-               <quote xml:lang="en">My husband wears a white shirt. We have a white
-                     car.</quote>
+               <quote xml:lang="en">My husband wears a white shirt. We have a white car.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00596">ṛāžli</w>
                      <w xml:id="wid_00597">lābis</w>
                      <w ana="semlib:shirt" xml:id="wid_00598">sūrīya</w>
-                        <w ana="semlib:white" xml:id="wid_00599">bīḏ̣a</w>
+                     <w ana="semlib:white" xml:id="wid_00599">bīḏ̣a</w>
                      <w xml:id="wid_00600" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_1625" join="right">-</pc>
                      <w xml:id="wid_00601">āna</w>
@@ -1060,7 +1032,7 @@
                      <w xml:id="wid_00606">/</w>
                      <w xml:id="wid_00607">ʕanna</w>
                      <w xml:id="wid_00608">kaṛhaba</w>
-                        <w xml:id="wid_00609">bīḏ̣a</w>
+                     <w xml:id="wid_00609">bīḏ̣a</w>
                      <pc type="ws" xml:id="id_pc_1644">.</pc>
                   </quote>
                </cit>
@@ -1099,7 +1071,7 @@
                      <w xml:id="wid_00635">maryūl</w>
                      <w xml:id="wid_00636" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_1706" join="right">-</pc>
-                        <w ana="semlib:black" xml:id="wid_00637">akḥal</w>
+                     <w ana="semlib:black" xml:id="wid_00637">akḥal</w>
                      <pc type="ws" xml:id="id_pc_1708">.</pc>
                      <w xml:id="wid_00638">/</w>
                      <w xml:id="wid_00639" join="right">hā</w>
@@ -1109,7 +1081,7 @@
                      <w xml:id="wid_00641">kaṛhaba</w>
                      <w xml:id="wid_00642" join="right">l</w>
                      <pc type="ws" xml:id="id_pc_1719" join="right">-</pc>
-                        <w xml:id="wid_00643">kaḥla</w>
+                     <w xml:id="wid_00643">kaḥla</w>
                      <pc type="ws" xml:id="id_pc_1721">.</pc>
                   </quote>
                </cit>
@@ -1133,11 +1105,11 @@
                      <w xml:id="wid_00660">maṛti</w>
                      <w xml:id="wid_00661">šrāt</w>
                      <w xml:id="wid_00662">maryūl</w>
-                        <w ana="semlib:pink" xml:id="wid_00663">waṛdi</w>
+                     <w ana="semlib:pink" xml:id="wid_00663">waṛdi</w>
                      <pc type="ws" xml:id="id_pc_1769">.</pc>
                      <w xml:id="wid_00664">/</w>
                      <w xml:id="wid_00665">sāk</w>
-                        <w xml:id="wid_00666">waṛdi</w>
+                     <w xml:id="wid_00666">waṛdi</w>
                      <pc type="ws" xml:id="id_pc_1776">.</pc>
                      <pc type="ws" xml:id="id_pc_1778" join="right">(</pc>
                      <w xml:id="wid_00667">maryūl</w>
@@ -1145,7 +1117,7 @@
                      <pc type="ws" xml:id="id_pc_1782" join="right">-</pc>
                      <w xml:id="wid_00669" join="right">ir</w>
                      <pc type="ws" xml:id="id_pc_1784" join="right">-</pc>
-                        <w xml:id="wid_00670">rose</w>
+                     <w xml:id="wid_00670">rose</w>
                      <pc type="ws" xml:id="id_pc_1786">.</pc>
                      <w xml:id="wid_00671">/</w>
                      <w xml:id="wid_00672">sāk</w>
@@ -1153,7 +1125,7 @@
                      <pc type="ws" xml:id="id_pc_1793" join="right">-</pc>
                      <w xml:id="wid_00674" join="right">ir</w>
                      <pc type="ws" xml:id="id_pc_1795" join="right">-</pc>
-                        <w xml:id="wid_00675">rose</w>
+                     <w xml:id="wid_00675">rose</w>
                      <pc type="ws" xml:id="id_pc_1797" join="right">.</pc>
                      <pc type="ws" xml:id="id_pc_1798">)</pc>
                   </quote>
@@ -1179,16 +1151,16 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00691">ḥīṭ</w>
-                        <w ana="semlib:grey" xml:id="wid_00692">ərmādi</w>
+                     <w ana="semlib:grey" xml:id="wid_00692">ərmādi</w>
                      <w xml:id="wid_00693">/</w>
                      <w xml:id="wid_00694">sāk</w>
-                        <w xml:id="wid_00695">ərmādi</w>
+                     <w xml:id="wid_00695">ərmādi</w>
                      <pc type="ws" xml:id="id_pc_1847" join="right">(</pc>
                      <w xml:id="wid_00696">ḥīṭ</w>
-                        <w xml:id="wid_00697">gris</w>
+                     <w xml:id="wid_00697">gris</w>
                      <w xml:id="wid_00698">/</w>
                      <w xml:id="wid_00699">sāk</w>
-                        <w xml:id="wid_00700">gris</w>
+                     <w xml:id="wid_00700">gris</w>
                      <pc type="ws" xml:id="id_pc_1856">)</pc>
                   </quote>
                </cit>
@@ -1207,14 +1179,14 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00709">maryūl</w>
-                        <w ana="semlib:orange" xml:id="wid_00710">buṛdgāni</w>
+                     <w ana="semlib:orange" xml:id="wid_00710">buṛdgāni</w>
                      <pc type="ws" xml:id="id_pc_1883" join="right">(</pc>
                      <w xml:id="wid_00711">maryūl</w>
                      <w xml:id="wid_00712" join="right">f</w>
                      <pc type="ws" xml:id="id_pc_1887" join="right">-</pc>
                      <w xml:id="wid_00713" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_1889" join="right">-</pc>
-                        <w xml:id="wid_00714">orange</w>
+                     <w xml:id="wid_00714">orange</w>
                      <pc type="ws" xml:id="id_pc_1891">)</pc>
                   </quote>
                </cit>
@@ -1242,7 +1214,7 @@
                      <w xml:id="wid_00725">in</w>
                      <w xml:id="wid_00726">ṭālib</w>
                      <w xml:id="wid_00727">ždīd</w>
-                        <w xml:id="wid_00728" ana="semlib:fi_vs_bi">f</w>
+                     <w xml:id="wid_00728" ana="semlib:fi_vs_bi">f</w>
                      <pc type="ws" xml:id="id_pc_1937" join="right">-</pc>
                      <w xml:id="wid_00729" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_1939" join="right">-</pc>
@@ -1274,7 +1246,7 @@
                   <quote xml:lang="ar">
                      <w xml:id="wid_00744" join="right">āš/š</w>
                      <pc type="ws" xml:id="id_pc_1987" join="right">-</pc>
-                        <w ana="semlib:to_do" xml:id="wid_00745">ʕāmla</w>
+                     <w ana="semlib:to_do" xml:id="wid_00745">ʕāmla</w>
                      <w xml:id="wid_00746" join="right">taww</w>
                      <pc type="ws" xml:id="id_pc_1991" join="right">(</pc>
                      <w xml:id="wid_00747" join="right">a</w>
@@ -1315,7 +1287,7 @@
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_stay" xml:id="wid_00771">uqʕud</w>
+                     <w ana="semlib:to_stay" xml:id="wid_00771">uqʕud</w>
                      <w xml:id="wid_00772" join="right">šwayya</w>
                      <pc type="ws" xml:id="id_pc_2058">!</pc>
                      <w xml:id="wid_00773">–</w>
@@ -1351,7 +1323,7 @@
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_speak" xml:id="wid_00794">titkallim</w>
+                     <w ana="semlib:to_speak" xml:id="wid_00794">titkallim</w>
                      <w xml:id="wid_00795" join="right">b</w>
                      <pc type="ws" xml:id="id_pc_2118" join="right">-</pc>
                      <w xml:id="wid_00796" join="right">il</w>
@@ -1386,11 +1358,10 @@
                      <w xml:id="wid_00813">ilbāraḥ/imbāraḥ</w>
                      <phr ana="semlib:to_rain">
                         <w xml:id="wid_00814">ṣabb</w>
-                        
                         <w xml:id="wid_00815" join="right">li</w>
                         <pc type="ws" xml:id="id_pc_2168" join="right">-</pc>
                         <w xml:id="wid_00816">mṭaṛ</w>
-                        </phr>
+                     </phr>
                      <pc type="ws" xml:id="id_pc_2170">.</pc>
                   </quote>
                </cit>
@@ -1408,7 +1379,7 @@
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_open" xml:id="wid_00820">ḥill</w>
+                     <w ana="semlib:to_open" xml:id="wid_00820">ḥill</w>
                      <w xml:id="wid_00821" join="right">iš</w>
                      <pc type="ws" xml:id="id_pc_2189" join="right">-</pc>
                      <w ana="semlib:window" xml:id="wid_00822" join="right">šubbāk</w>
@@ -1430,7 +1401,7 @@
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_close" xml:id="wid_00829">sakkir</w>
+                     <w ana="semlib:to_close" xml:id="wid_00829">sakkir</w>
                      <w xml:id="wid_00830" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_2216" join="right">-</pc>
                      <w xml:id="wid_00831" join="right">bībān</w>
@@ -1452,7 +1423,7 @@
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_00837">šnūwa</w>
-                        <w ana="semlib:to_take" xml:id="wid_00838">xḏīt</w>
+                     <w ana="semlib:to_take" xml:id="wid_00838">xḏīt</w>
                      <pc type="ws" xml:id="id_pc_2240">?</pc>
                      <w xml:id="wid_00839">–</w>
                      <w xml:id="wid_00840">ḥatta</w>
@@ -1476,11 +1447,10 @@
             </cit>
             <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
-               <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
-                     him.</quote>
+               <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to him.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_give" xml:id="wid_00855">ʕṭīt</w>
+                     <w ana="semlib:to_give" xml:id="wid_00855">ʕṭīt</w>
                      <pc type="ws" xml:id="id_pc_2287" join="right">-</pc>
                      <w xml:id="wid_00856">ši</w>
                      <w xml:id="wid_00857" join="right">ž</w>
@@ -1529,7 +1499,7 @@
                      <w xml:id="wid_00885" join="right">iz</w>
                      <pc type="ws" xml:id="id_pc_2359" join="right">-</pc>
                      <w ana="semlib:children" xml:id="wid_00886">zġāṛ</w>
-                        <w ana="semlib:to_see" xml:id="wid_00887">šāfu</w>
+                     <w ana="semlib:to_see" xml:id="wid_00887">šāfu</w>
                      <w xml:id="wid_00888">ṭallāb</w>
                      <w xml:id="wid_00889">wṛā</w>
                      <w ana="semlib:house" xml:id="wid_00890" join="right">dāṛ</w>
@@ -1553,11 +1523,10 @@
             </cit>
             <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
-               <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
-                     please.</quote>
+               <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea please.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_want" xml:id="wid_00904">tḥibb</w>
+                     <w ana="semlib:to_want" xml:id="wid_00904">tḥibb</w>
                      <w xml:id="wid_00905">tušṛub</w>
                      <w ana="semlib:tea" xml:id="wid_00906">tāy</w>
                      <w xml:id="wid_00907">walla</w>
@@ -1566,7 +1535,6 @@
                      <w xml:id="wid_00909">–</w>
                      <phr ana="semlib:please">
                         <w xml:id="wid_00910">māḏā</w>
-                     
                         <w xml:id="wid_00911">bīya</w>
                      </phr>
                      <w xml:id="wid_00912" join="right">tāy</w>
@@ -1591,11 +1559,10 @@
             </cit>
             <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
-               <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
-                     you.</quote>
+               <quote xml:lang="en">Bring me the big bottle, please! – I'm right with you.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_bring" xml:id="wid_00932">žīb</w>
+                     <w ana="semlib:to_bring" xml:id="wid_00932">žīb</w>
                      <w xml:id="wid_00933">li</w>
                      <w xml:id="wid_00934" join="right">d</w>
                      <pc type="ws" xml:id="id_pc_2479" join="right">-</pc>
@@ -1630,7 +1597,7 @@
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:to_have" xml:id="wid_00957">ʕand</w>
+                     <w ana="semlib:to_have" xml:id="wid_00957">ʕand</w>
                      <w xml:id="wid_00958">hum</w>
                      <w ana="semlib:much" xml:id="wid_00959">baṛša</w>
                      <w ana="semlib:money" xml:id="wid_00960" join="right">flūs</w>
@@ -1666,15 +1633,13 @@
             <head>Phrasemes</head>
             <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
-               <note xml:space="preserve">Many Arabic dialects
-                     use periphrastic constructions to render
-                     English ‛since’.</note>
+               <note xml:space="preserve">Many Arabic dialects use periphrastic constructions to render English ‛since’.</note>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:since_for" xml:id="wid_00984">ʕandna</w>
+                     <w ana="semlib:since_for" xml:id="wid_00984">ʕandna</w>
                      <w xml:id="wid_00985">/</w>
-                        <w xml:id="wid_00986">ʕanna</w>
+                     <w xml:id="wid_00986">ʕanna</w>
                      <w xml:id="wid_00987">ṯmānya</w>
                      <w xml:id="wid_00988">snīn</w>
                      <w xml:id="wid_00989">hūni</w>
@@ -1700,8 +1665,7 @@
             <head>Nouns</head>
             <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
-               <quote xml:lang="en">What are those women doing there? – They are baking
-                     bread.</quote>
+               <quote xml:lang="en">What are those women doing there? – They are baking bread.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="wid_01003" join="right">āš/š</w>
@@ -1711,7 +1675,7 @@
                      <pc type="ws" xml:id="id_pc_2672" join="right">-</pc>
                      <w xml:id="wid_01006" join="right">li</w>
                      <pc type="ws" xml:id="id_pc_2674" join="right">-</pc>
-                        <w ana="semlib:women" xml:id="wid_01007">nsā</w>
+                     <w ana="semlib:women" xml:id="wid_01007">nsā</w>
                      <pc type="ws" xml:id="id_pc_2676">?</pc>
                      <w xml:id="wid_01008">–</w>
                      <w xml:id="wid_01009">yṭayybu</w>
@@ -1743,7 +1707,7 @@
                <quote xml:lang="en">My husband wears a white shirt.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:husband" xml:id="wid_01027">ṛāžl</w>
+                     <w ana="semlib:husband" xml:id="wid_01027">ṛāžl</w>
                      <w xml:id="wid_01028">i</w>
                      <w xml:id="wid_01029">lābis</w>
                      <w xml:id="wid_01030">sūrīya</w>
@@ -1775,7 +1739,7 @@
                      <pc type="ws" xml:id="id_pc_2763">?</pc>
                      <w xml:id="wid_01045">–</w>
                      <w xml:id="wid_01046">hūwa</w>
-                        <w ana="semlib:friend" xml:id="wid_01047">ṣāḥb</w>
+                     <w ana="semlib:friend" xml:id="wid_01047">ṣāḥb</w>
                      <w xml:id="wid_01048" join="right">i</w>
                      <pc type="ws" xml:id="id_pc_2771">.</pc>
                   </quote>
@@ -1807,7 +1771,7 @@
                      <w xml:id="wid_01063">wīn</w>
                      <w xml:id="wid_01064" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_2822" join="right">-</pc>
-                        <w ana="semlib:mobile" xml:id="wid_01065">buṛṭābil</w>
+                     <w ana="semlib:mobile" xml:id="wid_01065">buṛṭābil</w>
                      <w xml:id="wid_01066" join="right">imtāʕi</w>
                      <pc type="ws" xml:id="id_pc_2826">?</pc>
                      <w xml:id="wid_01067">–</w>
@@ -1851,7 +1815,7 @@
                         <w xml:id="wid_01088" join="right">nnažžmū</w>
                         <pc type="ws" xml:id="id_pc_2894" join="right">-</pc>
                         <w xml:id="wid_01089">š</w>
-                        </phr>
+                     </phr>
                      <w xml:id="wid_01090">nxallṣu</w>
                      <w xml:id="wid_01091" join="right">l</w>
                      <pc type="ws" xml:id="id_pc_2900" join="right">-</pc>
@@ -1876,7 +1840,7 @@
                <quote xml:lang="en">Can you (~do you know how to) play Shqubba? – Yes.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:ability" xml:id="wid_01104">taʕraf</w>
+                     <w ana="semlib:ability" xml:id="wid_01104">taʕraf</w>
                      <pc type="ws" xml:id="id_pc_2935" join="right">-</pc>
                      <w xml:id="wid_01105">ši</w>
                      <w xml:id="wid_01106">talʕab</w>
@@ -1932,7 +1896,7 @@
                      <w xml:id="wid_01127" join="right">ʕarbi</w>
                      <pc type="ws" xml:id="id_pc_3012">?</pc>
                      <w xml:id="wid_01128">–</w>
-                        <w ana="semlib:a_little" xml:id="wid_01129">šwayya</w>
+                     <w ana="semlib:a_little" xml:id="wid_01129">šwayya</w>
                      <w xml:id="wid_01130" join="right">baṛka</w>
                      <pc type="ws" xml:id="id_pc_3019">.</pc>
                   </quote>
@@ -1956,7 +1920,7 @@
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:existential" xml:id="wid_01143">famma</w>
+                     <w ana="semlib:existential" xml:id="wid_01143">famma</w>
                      <w xml:id="wid_01144" join="right">ṯmunṭāš</w>
                      <pc type="ws" xml:id="id_pc_3057" join="right">-</pc>
                      <w xml:id="wid_01145">in</w>
@@ -1993,7 +1957,7 @@
                      <w xml:id="wid_01165" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_3107" join="right">-</pc>
                      <w xml:id="wid_01166">buṛṭābil</w>
-                        <w xml:id="wid_01167">imtāʕi</w>
+                     <w xml:id="wid_01167">imtāʕi</w>
                      <pc type="ws" xml:id="id_pc_3111">?</pc>
                      <w xml:id="wid_01168">–</w>
                      <phr ana="semlib:gen_explicative">
@@ -2001,7 +1965,6 @@
                         <w xml:id="wid_01169" join="right">a</w>
                         <pc type="ws" xml:id="id_pc_3117" join="right">)</pc>
                         <w xml:id="wid_01170">hāwa</w>
-                     
                         <w xml:id="wid_01171">hnā</w>
                      </phr>
                      <w xml:id="wid_01172">/</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -598,7 +598,7 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit ana="semlib:presentational_m" type="featureSample">
+            <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">here is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
@@ -616,10 +616,10 @@
                         <pc type="ws" xml:id="id_pc_979" join="right">)</pc>
                         <w xml:id="wid_00359">hāwa</w>
                      </phr>
-                     <w xml:id="wid_00360" ana="semlib:presentational_m">hnā</w>
+                     <w xml:id="wid_00360">hnā</w>
                      <pc type="ws" xml:space="preserve">/</pc>
                      <w xml:id="wid_00362">hāw</w>
-                     <w xml:id="wid_00363" ana="semlib:presentational_m">əhnā</w>
+                     <w xml:id="wid_00363">əhnā</w>
                      <pc type="ws" xml:id="id_pc_989">.</pc>
                   </quote>
                </cit>
@@ -638,7 +638,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:presentational_f" type="featureSample">
+            <cit ana="fvlib:pres_f_sg" type="featureSample">
                <lbl xml:space="preserve">here is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p xml:id="id_p_12">
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -46,7 +41,7 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
@@ -81,7 +76,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
@@ -137,7 +132,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -180,7 +175,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy</hi> or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -188,7 +183,7 @@
                <quote xml:lang="en">Why didn’t he come? – I don’t know. </quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                        <w ana="semlib:why" xml:id="wid_00090">ʕlāš</w>
+                     <w ana="semlib:why" xml:id="wid_00090">ʕlāš</w>
                      <w xml:id="wid_00091" join="right">ma</w>
                      <pc type="ws" xml:id="id_pc_271" join="right">-</pc>
                      <w xml:id="wid_00092" join="right">žā</w>
@@ -221,7 +216,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
@@ -262,7 +257,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -302,7 +297,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      ….</quote>
@@ -342,7 +337,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -383,7 +378,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -426,7 +421,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:lemon" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Pounds. </quote>
                <cit type="translation">
@@ -461,7 +456,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
@@ -505,7 +500,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
@@ -548,7 +543,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -603,8 +598,8 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit type="featureSample">
-               <lbl xml:space="preserve">there is … (m.)</lbl>
+            <cit ana="semlib:presentational_m" type="featureSample">
+               <lbl xml:space="preserve">here is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
@@ -621,10 +616,10 @@
                         <pc type="ws" xml:id="id_pc_979" join="right">)</pc>
                         <w xml:id="wid_00359">hāwa</w>
                      </phr>
-                     <w xml:id="wid_00360">hnā</w>
+                     <w xml:id="wid_00360" ana="semlib:presentational_m">hnā</w>
                      <pc type="ws" xml:space="preserve">/</pc>
                      <w xml:id="wid_00362">hāw</w>
-                        <w xml:id="wid_00363">əhnā</w>
+                     <w xml:id="wid_00363" ana="semlib:presentational_m">əhnā</w>
                      <pc type="ws" xml:id="id_pc_989">.</pc>
                   </quote>
                </cit>
@@ -643,8 +638,8 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
-               <lbl xml:space="preserve">there is … (f.)</lbl>
+            <cit ana="semlib:presentational_f" type="featureSample">
+               <lbl xml:space="preserve">here is … (f.)</lbl>
                <quote xml:lang="en">Where is the car? – Here it is!</quote>
                <cit type="translation">
                   <quote xml:lang="ar"/>
@@ -667,7 +662,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="semlib:here">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -701,7 +696,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:now">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -748,7 +743,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:today">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -777,7 +772,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:yesterday">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -808,7 +803,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:tomorrow">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -834,7 +829,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:last_year">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -874,7 +869,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="semlib:eight">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -902,7 +897,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eleven">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -935,7 +930,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:twelve">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -967,7 +962,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eighteen">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -1003,7 +998,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="semlib:good">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -1044,7 +1039,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="semlib:white">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1087,7 +1082,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:black">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -1130,7 +1125,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:pink">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -1178,7 +1173,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:grey">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall/a grey bag</quote>
                <cit type="translation">
@@ -1206,7 +1201,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:orange">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
@@ -1234,7 +1229,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semlib:fi_vs_bi" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -1247,7 +1242,7 @@
                      <w xml:id="wid_00725">in</w>
                      <w xml:id="wid_00726">ṭālib</w>
                      <w xml:id="wid_00727">ždīd</w>
-                        <w xml:id="wid_00728">f</w>
+                        <w xml:id="wid_00728" ana="semlib:fi_vs_bi">f</w>
                      <pc type="ws" xml:id="id_pc_1937" join="right">-</pc>
                      <w xml:id="wid_00729" join="right">il</w>
                      <pc type="ws" xml:id="id_pc_1939" join="right">-</pc>
@@ -1272,7 +1267,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="semlib:to_do">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -1315,7 +1310,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_stay">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -1351,7 +1346,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_speak">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1383,7 +1378,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_rain">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -1408,7 +1403,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_open">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -1430,7 +1425,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_close">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -1451,7 +1446,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_take">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1479,7 +1474,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_give">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
@@ -1526,7 +1521,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_see">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1556,7 +1551,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_want">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
@@ -1594,7 +1589,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_bring">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I'm right with
                      you.</quote>
@@ -1630,7 +1625,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_have">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1669,7 +1664,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
@@ -1703,7 +1698,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="semlib:women">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
@@ -1743,7 +1738,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:husband">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt.</quote>
                <cit type="translation">
@@ -1766,7 +1761,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:friend">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -1804,7 +1799,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1845,7 +1840,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="semlib:being_unable">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1876,7 +1871,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:ability">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play Shqubba? – Yes.</quote>
                <cit type="translation">
@@ -1905,7 +1900,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:possibility">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1924,7 +1919,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="semlib:a_little">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1956,7 +1951,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:existential" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -1989,7 +1984,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:gen_explicative" type="featureSample">
                <lbl xml:space="preserve">Genitive explicative</lbl>
                <quote xml:lang="en">Where is my mobile? – Here it is!</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
@@ -12,8 +12,7 @@
             <date>2018</date>
             <availability status="restricted">
                <p xml:id="id_p_12">
-                  <ref type="license"
-                       target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
                </p>
             </availability>
          </publicationStmt>
@@ -23,12 +22,8 @@
       </fileDesc>
       <encodingDesc>
          <listPrefixDef>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1"
-                       ident="semlib"/>
-            <prefixDef matchPattern="(.+)"
-                       replacementPattern="../vocabs/fLib.xml#$1"
-                       ident="fvlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#$1" ident="semlib"/>
+            <prefixDef matchPattern="(.+)" replacementPattern="../vocabs/fLib.xml#$1" ident="fvlib"/>
          </listPrefixDef>
       </encodingDesc>
    </teiHeader>
@@ -46,7 +41,7 @@
          </div>
          <div type="featureGroup">
             <head>Interrogatives</head>
-            <cit type="featureSample">
+            <cit ana="semlib:who" type="featureSample">
                <lbl xml:space="preserve">who?</lbl>
                <note xml:space="preserve">Most commonly dialects show reflexes of CA <hi rend="italic">man</hi>.</note>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
@@ -81,7 +76,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:whose" type="featureSample">
                <lbl xml:space="preserve">whose?</lbl>
                <quote xml:lang="en">Whose car is this? – This is our car. It’s small but it’s
                      good.</quote>
@@ -137,7 +132,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:what" type="featureSample">
                <lbl xml:space="preserve">what?</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -178,7 +173,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:why" type="featureSample">
                <lbl xml:space="preserve">why?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">li
                         + ’ayy </hi>or <hi rend="italic">li + ’ayy + šay’</hi>
@@ -214,7 +209,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where" type="featureSample">
                <lbl xml:space="preserve">where?</lbl>
                <note xml:space="preserve">A very common pattern are reflexes of CA <hi rend="italic">fī
                         + ’ayna</hi>
@@ -245,7 +240,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_to" type="featureSample">
                <lbl xml:space="preserve">where to?</lbl>
                <quote xml:lang="en">Where are you (m./f.) going? – I am going home.</quote>
                <cit type="translation">
@@ -282,7 +277,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:where_from" type="featureSample">
                <lbl xml:space="preserve">where from?</lbl>
                <quote xml:lang="en">Where are you (m./f.; sg./pl.) from? – I am/ We are from
                      Harran.</quote>
@@ -319,7 +314,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:when" type="featureSample">
                <lbl xml:space="preserve">when?</lbl>
                <quote xml:lang="en">Fatima, when did you see Muhammad? – I saw him yesterday. </quote>
                <cit type="translation">
@@ -357,7 +352,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how" type="featureSample">
                <lbl xml:space="preserve">how?</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -394,7 +389,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_much" type="featureSample">
                <lbl xml:space="preserve">how much?</lbl>
                <quote xml:lang="en">How much is half a kilo of lemons? – It’s 10 Lira. </quote>
                <cit type="translation">
@@ -428,7 +423,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:how_many" type="featureSample">
                <lbl xml:space="preserve">how many?</lbl>
                <quote xml:lang="en">How many children do you (f.) have? – I have
                      two daughters
@@ -468,7 +463,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample">
+            <cit ana="semlib:which" type="featureSample">
                <lbl xml:space="preserve">which?</lbl>
                <quote xml:lang="en">In which neighbourhood do you live? – We live in Zamalik. </quote>
                <cit type="translation">
@@ -507,7 +502,7 @@
          </div>
          <div type="featureGroup">
             <head>Demonstratives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:dempron_prox_m_sg" type="featureSample">
                <lbl xml:space="preserve">this</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend</quote>
                <cit type="translation">
@@ -561,7 +556,7 @@
          </div>
          <div type="featureGroup">
             <head>Presentatives</head>
-            <cit type="featureSample">
+            <cit ana="fvlib:pres_m_sg" type="featureSample">
                <lbl xml:space="preserve">there is … (m.)</lbl>
                <quote xml:lang="en">Where is my mobile? – Here is the phone!</quote>
                <cit type="translation">
@@ -613,7 +608,7 @@
          </div>
          <div type="featureGroup">
             <head>Adverbs</head>
-            <cit type="featureSample" ana="semlib:here">
+            <cit ana="semlib:here" type="featureSample">
                <lbl xml:space="preserve">here</lbl>
                <quote xml:lang="en">We have been here for 8 years.</quote>
                <cit type="translation">
@@ -640,7 +635,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:now">
+            <cit ana="semlib:now" type="featureSample">
                <lbl xml:space="preserve">now</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV. </quote>
                <cit type="translation">
@@ -681,7 +676,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:today">
+            <cit ana="semlib:today" type="featureSample">
                <lbl xml:space="preserve">today</lbl>
                <quote xml:lang="en">It’s very hot today.</quote>
                <cit type="translation">
@@ -710,7 +705,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:yesterday">
+            <cit ana="semlib:yesterday" type="featureSample">
                <lbl xml:space="preserve">yesterday</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -732,7 +727,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:tomorrow">
+            <cit ana="semlib:tomorrow" type="featureSample">
                <lbl xml:space="preserve">tomorrow</lbl>
                <quote xml:lang="en">Hey kids, tomorrow you have to study.</quote>
                <cit type="translation">
@@ -759,7 +754,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:last_year">
+            <cit ana="semlib:last_year" type="featureSample">
                <lbl xml:space="preserve">last year</lbl>
                <quote xml:lang="en">Last year we had many problems.</quote>
                <cit type="translation">
@@ -787,7 +782,7 @@
          </div>
          <div type="featureGroup">
             <head>Numerals</head>
-            <cit type="featureSample" ana="semlib:eight">
+            <cit ana="semlib:eight" type="featureSample">
                <lbl xml:space="preserve">eight</lbl>
                <quote xml:lang="en">We have been here for 8 years. </quote>
                <cit type="translation">
@@ -814,7 +809,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eleven">
+            <cit ana="semlib:eleven" type="featureSample">
                <lbl xml:space="preserve">eleven</lbl>
                <quote xml:lang="en">What’s the time? It’s 11 o’clock.</quote>
                <cit type="translation">
@@ -848,7 +843,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:twelve">
+            <cit ana="semlib:twelve" type="featureSample">
                <lbl xml:space="preserve">twelve</lbl>
                <quote xml:lang="en">They have 12 goats and 2 cows.</quote>
                <cit type="translation">
@@ -875,7 +870,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:eighteen">
+            <cit ana="semlib:eighteen" type="featureSample">
                <lbl xml:space="preserve">eighteen</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -906,7 +901,7 @@
          </div>
          <div type="featureGroup">
             <head>Adjectives</head>
-            <cit type="featureSample" ana="semlib:good">
+            <cit ana="semlib:good" type="featureSample">
                <lbl xml:space="preserve">good</lbl>
                <quote xml:lang="en">How are you (m./f.)? – I’m fine.</quote>
                <cit type="translation">
@@ -944,7 +939,7 @@
          </div>
          <div type="featureGroup">
             <head>Colours</head>
-            <cit type="featureSample" ana="semlib:white">
+            <cit ana="semlib:white" type="featureSample">
                <lbl xml:space="preserve">white</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -984,7 +979,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:black">
+            <cit ana="semlib:black" type="featureSample">
                <lbl xml:space="preserve">black</lbl>
                <quote xml:lang="en">I don’t like this black shirt. / car.</quote>
                <cit type="translation">
@@ -1017,7 +1012,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:pink">
+            <cit ana="semlib:pink" type="featureSample">
                <lbl xml:space="preserve">pink</lbl>
                <quote xml:lang="en">My wife bought a pink shirt / bag.</quote>
                <cit type="translation">
@@ -1040,7 +1035,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:grey">
+            <cit ana="semlib:grey" type="featureSample">
                <lbl xml:space="preserve">grey</lbl>
                <quote xml:lang="en">a grey wall / a grey bag</quote>
                <cit type="translation">
@@ -1063,7 +1058,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:orange">
+            <cit ana="semlib:orange" type="featureSample">
                <lbl xml:space="preserve">orange</lbl>
                <quote xml:lang="en">an orange shirt / car</quote>
                <cit type="translation">
@@ -1082,7 +1077,7 @@
          </div>
          <div type="featureGroup">
             <head>Prepositions</head>
-            <cit type="featureSample">
+            <cit ana="semlib:in" type="featureSample">
                <lbl xml:space="preserve">
                   <hi rend="italic">fi</hi> vs. <hi rend="italic">bi</hi>
                </lbl>
@@ -1115,7 +1110,7 @@
          </div>
          <div type="featureGroup">
             <head>Important verbs</head>
-            <cit type="featureSample" ana="semlib:to_do">
+            <cit ana="semlib:to_do" type="featureSample">
                <lbl xml:space="preserve">to do</lbl>
                <quote xml:lang="en">Fatima, what are you doing now? – I’m watching TV.</quote>
                <cit type="translation">
@@ -1156,7 +1151,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_stay">
+            <cit ana="semlib:to_stay" type="featureSample">
                <lbl xml:space="preserve">to stay</lbl>
                <quote xml:lang="en">Stay a bit longer! – No, I don’t have time.</quote>
                <cit type="translation">
@@ -1189,7 +1184,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_speak">
+            <cit ana="semlib:to_speak" type="featureSample">
                <lbl xml:space="preserve">to speak</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">
@@ -1220,7 +1215,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_rain">
+            <cit ana="semlib:to_rain" type="featureSample">
                <lbl xml:space="preserve">to rain</lbl>
                <quote xml:lang="en">Yesterday it rained.</quote>
                <cit type="translation">
@@ -1245,7 +1240,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_open">
+            <cit ana="semlib:to_open" type="featureSample">
                <lbl xml:space="preserve">to open</lbl>
                <quote xml:lang="en">Open the window!</quote>
                <cit type="translation">
@@ -1267,7 +1262,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_close">
+            <cit ana="semlib:to_close" type="featureSample">
                <lbl xml:space="preserve">to close</lbl>
                <quote xml:lang="en">Close the doors!</quote>
                <cit type="translation">
@@ -1288,7 +1283,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_take">
+            <cit ana="semlib:to_take" type="featureSample">
                <lbl xml:space="preserve">to take</lbl>
                <quote xml:lang="en">What did you take? – Nothing.</quote>
                <cit type="translation">
@@ -1316,7 +1311,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_give">
+            <cit ana="semlib:to_give" type="featureSample">
                <lbl xml:space="preserve">to give</lbl>
                <quote xml:lang="en">Did you give the letter to Ahmad? – Yes, I gave it to
                      him.</quote>
@@ -1359,7 +1354,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_see">
+            <cit ana="semlib:to_see" type="featureSample">
                <lbl xml:space="preserve">to see</lbl>
                <quote xml:lang="en">The children saw a beggar behind our house.</quote>
                <cit type="translation">
@@ -1389,7 +1384,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_want">
+            <cit ana="semlib:to_want" type="featureSample">
                <lbl xml:space="preserve">to want</lbl>
                <quote xml:lang="en">Do you (f.) want to drink tea or coffee? – Tea
                      please.</quote>
@@ -1427,7 +1422,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_bring">
+            <cit ana="semlib:to_bring" type="featureSample">
                <lbl xml:space="preserve">to bring</lbl>
                <quote xml:lang="en">Bring me the big bottle, please! – I’m right with
                      you.</quote>
@@ -1465,7 +1460,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:to_have">
+            <cit ana="semlib:to_have" type="featureSample">
                <lbl xml:space="preserve">to have</lbl>
                <quote xml:lang="en">They have a lot of money, but they are bad people.</quote>
                <cit type="translation">
@@ -1503,7 +1498,7 @@
          </div>
          <div type="featureGroup">
             <head>Phrasemes</head>
-            <cit type="featureSample">
+            <cit ana="semlib:since_for" type="featureSample">
                <lbl xml:space="preserve">since/for</lbl>
                <note xml:space="preserve">Many Arabic dialects
                      use periphrastic constructions to render
@@ -1539,7 +1534,7 @@
          </div>
          <div type="featureGroup">
             <head>Nouns</head>
-            <cit type="featureSample" ana="semlib:women">
+            <cit ana="semlib:women" type="featureSample">
                <lbl xml:space="preserve">women</lbl>
                <quote xml:lang="en">What are those women doing there? – They are baking
                      bread.</quote>
@@ -1575,7 +1570,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:husband">
+            <cit ana="semlib:husband" type="featureSample">
                <lbl xml:space="preserve">husband</lbl>
                <quote xml:lang="en">My husband wears a white shirt. We have a white
                      car.</quote>
@@ -1602,7 +1597,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:friend">
+            <cit ana="semlib:friend" type="featureSample">
                <lbl xml:space="preserve">friend</lbl>
                <quote xml:lang="en">Who is this man? – He is my friend.</quote>
                <cit type="translation">
@@ -1639,7 +1634,7 @@
          </div>
          <div type="featureGroup">
             <head>Neologisms</head>
-            <cit type="featureSample">
+            <cit ana="semlib:mobile" type="featureSample">
                <lbl xml:space="preserve">mobile vs. cellphone</lbl>
                <quote xml:lang="en">Where is my mobile (phone)? – Here it is!</quote>
                <cit type="translation">
@@ -1671,7 +1666,7 @@
          </div>
          <div type="featureGroup">
             <head>Modality</head>
-            <cit type="featureSample" ana="semlib:being_unable">
+            <cit ana="semlib:being_unable" type="featureSample">
                <lbl xml:space="preserve">being unable</lbl>
                <quote xml:lang="en">We cannot pay the rent.</quote>
                <cit type="translation">
@@ -1701,7 +1696,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:ability">
+            <cit ana="semlib:ability" type="featureSample">
                <lbl xml:space="preserve">ability</lbl>
                <quote xml:lang="en">Can you (~do you know how to) play OK / Mangala? –
                      Yes.</quote>
@@ -1731,7 +1726,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit type="featureSample" ana="semlib:possibility">
+            <cit ana="semlib:possibility" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1750,7 +1745,7 @@
          </div>
          <div type="featureGroup">
             <head>Other items</head>
-            <cit type="featureSample" ana="semlib:a_little">
+            <cit ana="semlib:a_little" type="featureSample">
                <lbl xml:space="preserve">a little</lbl>
                <quote xml:lang="en">Do you speak Arabic? – Just, a little.</quote>
                <cit type="translation">


### PR DESCRIPTION
Note: Later we might want to detach features and labels from their examples so that any relevant sentence can show up for any feature if tagged properly, but now let;s just tag the wrappers to enable the highlights working as they were before.