### PR TITLE
Fix the remaining hashmarks and the missing semlib three problem

### DIFF
--- a/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
@@ -470,7 +470,7 @@
                      <w xml:id="wid_00254">banāt</w>
                      <w xml:id="wid_00255" join="right">w</w>
                      <pc xml:id="id_pc_798" join="right">-</pc>
-                     <w xml:id="wid_00256" ana="semlib:three #vt_phon_CA_th">ṯəlṯ</w>
+                     <w xml:id="wid_00256" ana="semlib:three vt_phon_CA_th">ṯəlṯ</w>
                      <w xml:id="wid_00257" join="right">awlād</w>
                      <pc xml:id="id_pc_802">.</pc>
                   </quote>
@@ -1514,7 +1514,7 @@
                      <w xml:id="wid_00841">təšrəb</w>
                      <w xml:id="wid_00842" ana="semlib:tea">čāy</w>
                      <w xml:id="wid_00843">lō</w>
-                     <w xml:id="wid_00844" ana="semlib:coffee #vt_phon_CA_q" join="right">gahwa</w>
+                     <w xml:id="wid_00844" ana="semlib:coffee vt_phon_CA_q" join="right">gahwa</w>
                      <pc xml:id="id_pc_2481">?</pc>
                      <pc xml:id="id_pc_2483">–</pc>
                      <w xml:id="wid_00845">čāy</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_ahwaz_toks.xml
@@ -470,7 +470,7 @@
                      <w xml:id="wid_00254">banāt</w>
                      <w xml:id="wid_00255" join="right">w</w>
                      <pc xml:id="id_pc_798" join="right">-</pc>
-                     <w xml:id="wid_00256" ana="semlib:three vt_phon_CA_th">ṯəlṯ</w>
+                     <w xml:id="wid_00256" ana="semlib:three fvlib:phon.CA_th">ṯəlṯ</w>
                      <w xml:id="wid_00257" join="right">awlād</w>
                      <pc xml:id="id_pc_802">.</pc>
                   </quote>
@@ -1514,7 +1514,7 @@
                      <w xml:id="wid_00841">təšrəb</w>
                      <w xml:id="wid_00842" ana="semlib:tea">čāy</w>
                      <w xml:id="wid_00843">lō</w>
-                     <w xml:id="wid_00844" ana="semlib:coffee vt_phon_CA_q" join="right">gahwa</w>
+                     <w xml:id="wid_00844" ana="semlib:coffee fvlib:phon.CA_q" join="right">gahwa</w>
                      <pc xml:id="id_pc_2481">?</pc>
                      <pc xml:id="id_pc_2483">–</pc>
                      <w xml:id="wid_00845">čāy</w>
@@ -1857,7 +1857,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1903,7 +1903,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:existential" type="featureSample">
+            <cit ana="fvlib:subc.exist" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -451,7 +451,7 @@
                      <w xml:id="wid_00274">bǝntēn</w>
                      <w xml:id="wid_00275">wǝ</w>
                      <pc type="ws" xml:id="id_pc_741" join="right">-</pc>
-                     <w ana="semlib:three vt_phon_CA_th" xml:id="wid_00276">tlaṯ</w>
+                     <w ana="semlib:three fvlib:phon.CA_th" xml:id="wid_00276">tlaṯ</w>
                      <w xml:id="wid_00277">wǝlǝd</w>
                      <pc type="ws" xml:id="id_pc_745">.</pc>
                   </quote>
@@ -1480,7 +1480,7 @@
                      <pc type="ws" xml:id="id_pc_2363" join="right">-</pc>
                         <w ana="semlib:to_want" xml:id="wid_00882">trīd</w>
                      <w xml:id="wid_00883">tišrab</w>
-                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="wid_00884">gahwa</w>
+                     <w ana="semlib:coffee fvlib:phon.CA_q" xml:id="wid_00884">gahwa</w>
                      <w xml:id="wid_00885">lō</w>
                      <w ana="semlib:tea" xml:id="wid_00886">čāy</w>
                      <pc type="ws" xml:id="id_pc_2373" join="right">?</pc>
@@ -1842,7 +1842,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">

--- a/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_baghdad_toks.xml
@@ -451,7 +451,7 @@
                      <w xml:id="wid_00274">bǝntēn</w>
                      <w xml:id="wid_00275">wǝ</w>
                      <pc type="ws" xml:id="id_pc_741" join="right">-</pc>
-                     <w ana="semlib:three #vt_phon_CA_th" xml:id="wid_00276">tlaṯ</w>
+                     <w ana="semlib:three vt_phon_CA_th" xml:id="wid_00276">tlaṯ</w>
                      <w xml:id="wid_00277">wǝlǝd</w>
                      <pc type="ws" xml:id="id_pc_745">.</pc>
                   </quote>
@@ -1480,7 +1480,7 @@
                      <pc type="ws" xml:id="id_pc_2363" join="right">-</pc>
                         <w ana="semlib:to_want" xml:id="wid_00882">trīd</w>
                      <w xml:id="wid_00883">tišrab</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00884">gahwa</w>
+                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="wid_00884">gahwa</w>
                      <w xml:id="wid_00885">lō</w>
                      <w ana="semlib:tea" xml:id="wid_00886">čāy</w>
                      <pc type="ws" xml:id="id_pc_2373" join="right">?</pc>

--- a/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
@@ -337,7 +337,7 @@
                      <w xml:id="id_216">bintēn</w>
                      <w xml:id="id_216a" ana="{ana}" join="right">w</w>
                      <w xml:id="id_216b" join="right">-</w>
-                     <w ana="vt_phon_CA_th semlib:three">talat</w>
+                     <w ana="fvlib:phon.CA_th semlib:three">talat</w>
                      <w xml:id="id_221" join="right">wilād</w>
                      <pc type="ws" xml:id="id_222">.</pc>
                   </quote>
@@ -1070,7 +1070,7 @@
                      <w xml:id="id_666">tišrabi</w>
                      <w ana="semlib:tea" xml:id="id_668">šāy</w>
                      <w xml:id="id_670">walla</w>
-                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="id_672" join="right">ʔahwa</w>
+                     <w ana="semlib:coffee fvlib:phon.CA_q" xml:id="id_672" join="right">ʔahwa</w>
                      <pc type="ws" xml:id="id_673">?</pc>
                      <w xml:id="id_675">–</w>
                      <w xml:id="id_677" join="right">šāy</w>
@@ -1281,12 +1281,12 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w ana="semlib:possibility" xml:id="id_781">tiʔdaṛ</w>
+                     <w ana="fvlib:subc.posbl" xml:id="id_781">tiʔdaṛ</w>
                                                                             <w xml:id="id_782_a">tīgi</w>
                      <w xml:id="id_784" join="right">bukṛa</w>
                      <pc type="ws" xml:id="id_785">?</pc>
@@ -1317,14 +1317,14 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit ana="semlib:existential" type="featureSample">
+            <cit ana="fvlib:subc.exist" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="id_796">fi</w>
                      <w xml:id="id_798">faṣlina</w>
-                        <w ana="semlib:existential" xml:id="id_800">fīh</w>
+                        <w ana="fvlib:subc.exist" xml:id="id_800">fīh</w>
                      <w xml:id="id_801">tamantāšar</w>
                      <w xml:id="id_803" join="right">ṭālib</w>
                      <w xml:id="id_804" join="right">gidīd</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_cairo_toks.xml
@@ -337,7 +337,7 @@
                      <w xml:id="id_216">bintēn</w>
                      <w xml:id="id_216a" ana="{ana}" join="right">w</w>
                      <w xml:id="id_216b" join="right">-</w>
-                     <w ana="#vt_phon_CA_th #vt_lex_three">talat</w>
+                     <w ana="vt_phon_CA_th semlib:three">talat</w>
                      <w xml:id="id_221" join="right">wilād</w>
                      <pc type="ws" xml:id="id_222">.</pc>
                   </quote>
@@ -1070,7 +1070,7 @@
                      <w xml:id="id_666">tišrabi</w>
                      <w ana="semlib:tea" xml:id="id_668">šāy</w>
                      <w xml:id="id_670">walla</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="id_672" join="right">ʔahwa</w>
+                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="id_672" join="right">ʔahwa</w>
                      <pc type="ws" xml:id="id_673">?</pc>
                      <w xml:id="id_675">–</w>
                      <w xml:id="id_677" join="right">šāy</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
@@ -306,7 +306,7 @@
                      <w xml:id="wid_00085">bǝntēn</w>
                      <w xml:id="wid_00086" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_313" join="right">-</pc>
-                     <w ana="vt_phon_CA_th semlib:three" xml:id="wid_00087">tlǝt</w>
+                     <w ana="fvlib:phon.CA_th semlib:three" xml:id="wid_00087">tlǝt</w>
                      <w xml:id="wid_00088" join="right">ǝwlād</w>
                      <pc type="ws" xml:id="id_pc_317">.</pc>
                   </quote>
@@ -1049,7 +1049,7 @@
                      <w xml:id="wid_00310_a">tǝšrabi</w>
                      <w ana="semlib:tea" xml:id="wid_00311">šāy</w>
                      <w xml:id="wid_00312">walla</w>
-                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="wid_00313" join="right">ʔahwe</w>
+                     <w ana="semlib:coffee fvlib:phon.CA_q" xml:id="wid_00313" join="right">ʔahwe</w>
                      <pc type="ws" xml:id="id_pc_1093">?</pc>
                      <w xml:id="wid_00314">–</w>
                      <w xml:id="wid_00315" join="right">šāy</w>
@@ -1301,7 +1301,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1338,7 +1338,7 @@
                   <quote xml:lang="de"/>
                </cit>
             </cit>
-            <cit ana="semlib:existential" type="featureSample">
+            <cit ana="fvlib:subc.exist" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
@@ -1346,7 +1346,7 @@
                      <w xml:id="wid_00397" join="right">b</w>
                      <pc type="ws" xml:id="id_pc_1413" join="right">-</pc>
                      <w xml:id="wid_00398">ṣaffna</w>
-                        <w ana="semlib:existential" xml:id="wid_00399">fī</w>
+                        <w ana="fvlib:subc.exist" xml:id="wid_00399">fī</w>
                      <w xml:id="wid_00400_a">tmǝnṭaʕšar</w>
                      <w xml:id="wid_00401" join="right">ṭāleb</w>
                      <w xml:id="wid_00402" join="right">ǝždīd</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_damascus_toks.xml
@@ -306,7 +306,7 @@
                      <w xml:id="wid_00085">bǝntēn</w>
                      <w xml:id="wid_00086" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_313" join="right">-</pc>
-                     <w ana="#vt_phon_CA_th #vt_lex_three" xml:id="wid_00087">tlǝt</w>
+                     <w ana="vt_phon_CA_th semlib:three" xml:id="wid_00087">tlǝt</w>
                      <w xml:id="wid_00088" join="right">ǝwlād</w>
                      <pc type="ws" xml:id="id_pc_317">.</pc>
                   </quote>
@@ -1049,7 +1049,7 @@
                      <w xml:id="wid_00310_a">tǝšrabi</w>
                      <w ana="semlib:tea" xml:id="wid_00311">šāy</w>
                      <w xml:id="wid_00312">walla</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00313" join="right">ʔahwe</w>
+                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="wid_00313" join="right">ʔahwe</w>
                      <pc type="ws" xml:id="id_pc_1093">?</pc>
                      <w xml:id="wid_00314">–</w>
                      <w xml:id="wid_00315" join="right">šāy</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
@@ -478,7 +478,7 @@
                      <w xml:id="id_677">banāwīt</w>
                      <w xml:id="id_679" join="right">w</w>
                      <pc type="ws" xml:id="id_680" join="right">-</pc>
-                     <w ana="semlib:three #vt_phon_CA_th" xml:id="id_681">ṯilṯ</w>
+                     <w ana="semlib:three vt_phon_CA_th" xml:id="id_681">ṯilṯ</w>
                      <w xml:id="id_683" join="right">awlād</w>
                      <pc type="ws" xml:id="id_684">.</pc>
                   </quote>
@@ -1496,7 +1496,7 @@
                      <w xml:id="id_2124_a">tašṛab</w>
                      <w ana="semlib:tea" xml:id="id_2126">tāy</w>
                      <w xml:id="id_2128">walla</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="id_2130" join="right">qahwa</w>
+                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="id_2130" join="right">qahwa</w>
                      <pc type="ws" xml:id="id_2131">?</pc>
                      <w xml:id="id_2133">–</w>
                      <w xml:id="id_2135" join="right">tāy</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_douz_toks.xml
@@ -478,7 +478,7 @@
                      <w xml:id="id_677">banāwīt</w>
                      <w xml:id="id_679" join="right">w</w>
                      <pc type="ws" xml:id="id_680" join="right">-</pc>
-                     <w ana="semlib:three vt_phon_CA_th" xml:id="id_681">ṯilṯ</w>
+                     <w ana="semlib:three fvlib:phon.CA_th" xml:id="id_681">ṯilṯ</w>
                      <w xml:id="id_683" join="right">awlād</w>
                      <pc type="ws" xml:id="id_684">.</pc>
                   </quote>
@@ -1496,7 +1496,7 @@
                      <w xml:id="id_2124_a">tašṛab</w>
                      <w ana="semlib:tea" xml:id="id_2126">tāy</w>
                      <w xml:id="id_2128">walla</w>
-                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="id_2130" join="right">qahwa</w>
+                     <w ana="semlib:coffee fvlib:phon.CA_q" xml:id="id_2130" join="right">qahwa</w>
                      <pc type="ws" xml:id="id_2131">?</pc>
                      <w xml:id="id_2133">–</w>
                      <w xml:id="id_2135" join="right">tāy</w>
@@ -1855,7 +1855,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1906,13 +1906,13 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:existential" type="featureSample">
+            <cit ana="fvlib:subc.exist" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
                      <w xml:id="id_2729">qisǝmna</w>
-                        <w ana="semlib:existential" xml:id="id_2731">fīh</w>
+                        <w ana="fvlib:subc.exist" xml:id="id_2731">fīh</w>
                      <w xml:id="id_2732_a" join="right">ṯumǝnṭāš</w>
                      <pc type="ws" xml:id="id_2733" join="right">-</pc>
                      <w xml:id="id_2734">in</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_rabat__toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_rabat__toks.xml
@@ -390,7 +390,7 @@
 							<seg type="ws" xml:space="preserve" xml:id="id_seg_356"> </seg>
 							<w xml:id="wid_00101">w</w>
 							<seg type="ws" xml:space="preserve" xml:id="id_seg_358"> </seg>
-							<w xml:id="wid_00102" ana="#vt_lex_three #vt_phon_CA_th">tlata</w>
+							<w xml:id="wid_00102" ana="#vt_lex_three #fvlib:phon.CA_th">tlata</w>
 							<seg type="ws" xml:space="preserve" xml:id="id_seg_360"> </seg>
 							<w xml:id="wid_00103">dyal</w>
 							<seg type="ws" xml:space="preserve" xml:id="id_seg_362"> </seg>
@@ -1328,7 +1328,7 @@
 							<seg type="ws" xml:space="preserve" xml:id="id_seg_1198"> </seg>
 							<w xml:id="wid_00327">l</w>
 							<pc type="ws" xml:space="preserve" xml:id="id_pc_1200">-</pc>
-							<w xml:id="wid_00328" ana="#vt_lex_coffee #vt_phon_CA_q">qəhwa</w>
+							<w xml:id="wid_00328" ana="#vt_lex_coffee #fvlib:phon.CA_q">qəhwa</w>
 							<pc type="ws" xml:space="preserve" xml:id="id_pc_1202">?</pc>
 							<seg type="ws" xml:space="preserve" xml:id="id_seg_1203"> </seg>
 							<w xml:id="wid_00329">‒</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -461,7 +461,7 @@
                      <w xml:id="wid_00276">bnāt</w>
                      <w xml:id="wid_00277" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_746" join="right">-</pc>
-                     <w ana="semlib:three vt_phon_CA_th" xml:id="wid_00278" join="right">tlāṯ</w>
+                     <w ana="semlib:three fvlib:phon.CA_th" xml:id="wid_00278" join="right">tlāṯ</w>
                      <pc type="ws" xml:id="id_pc_748" join="right">(</pc>
                      <w xml:id="wid_00279" join="right">a</w>
                      <pc type="ws" xml:id="id_pc_750">)</pc>
@@ -1530,7 +1530,7 @@
                      <w xml:id="wid_00905">tušṛub</w>
                      <w ana="semlib:tea" xml:id="wid_00906">tāy</w>
                      <w xml:id="wid_00907">walla</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00908" join="right">qahwa</w>
+                     <w ana="semlib:coffee #fvlib:phon.CA_q" xml:id="wid_00908" join="right">qahwa</w>
                      <pc type="ws" xml:id="id_pc_2415">?</pc>
                      <w xml:id="wid_00909">–</w>
                      <phr ana="semlib:please">
@@ -1864,7 +1864,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">
@@ -1915,12 +1915,12 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:existential" type="featureSample">
+            <cit ana="fvlib:subc.exist" type="featureSample">
                <lbl xml:space="preserve">existential (there is, there are)</lbl>
                <quote xml:lang="en">There are 18 new students in our class.</quote>
                <cit type="translation">
                   <quote xml:lang="ar">
-                     <w ana="semlib:existential" xml:id="wid_01143">famma</w>
+                     <w ana="fvlib:subc.exist" xml:id="wid_01143">famma</w>
                      <w xml:id="wid_01144" join="right">ṯmunṭāš</w>
                      <pc type="ws" xml:id="id_pc_3057" join="right">-</pc>
                      <w xml:id="wid_01145">in</w>

--- a/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_tunis_toks.xml
@@ -461,7 +461,7 @@
                      <w xml:id="wid_00276">bnāt</w>
                      <w xml:id="wid_00277" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_746" join="right">-</pc>
-                     <w ana="semlib:three #vt_phon_CA_th" xml:id="wid_00278" join="right">tlāṯ</w>
+                     <w ana="semlib:three vt_phon_CA_th" xml:id="wid_00278" join="right">tlāṯ</w>
                      <pc type="ws" xml:id="id_pc_748" join="right">(</pc>
                      <w xml:id="wid_00279" join="right">a</w>
                      <pc type="ws" xml:id="id_pc_750">)</pc>

--- a/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
@@ -439,7 +439,7 @@
                      <w xml:id="wid_00256">bnayytēn</w>
                      <w xml:id="wid_00257" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_700" join="right">-</pc>
-                     <w ana="semlib:three #vt_phon_CA_th" xml:id="wid_00258">ṯaliṯ</w>
+                     <w ana="semlib:three vt_phon_CA_th" xml:id="wid_00258">ṯaliṯ</w>
                      <w xml:id="wid_00259" join="right">walād</w>
                      <pc type="ws" xml:id="id_pc_704">.</pc>
                   </quote>
@@ -1393,7 +1393,7 @@
                      <w xml:id="wid_00819">tišrab</w>
                      <w ana="semlib:tea" xml:id="wid_00820">čāy</w>
                      <w xml:id="wid_00821">alli</w>
-                     <w ana="semlib:coffee #vt_phon_CA_q" xml:id="wid_00822" join="right">ghawa</w>
+                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="wid_00822" join="right">ghawa</w>
                      <pc type="ws" xml:id="id_pc_2226">?</pc>
                      <w xml:id="wid_00823">–</w>
                      <phr ana="semlib:please">

--- a/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
+++ b/vicav_lingfeatures/vicav_lingfeatures_urfa_toks.xml
@@ -439,7 +439,7 @@
                      <w xml:id="wid_00256">bnayytēn</w>
                      <w xml:id="wid_00257" join="right">w</w>
                      <pc type="ws" xml:id="id_pc_700" join="right">-</pc>
-                     <w ana="semlib:three vt_phon_CA_th" xml:id="wid_00258">ṯaliṯ</w>
+                     <w ana="semlib:three fvlib:phon.CA_th" xml:id="wid_00258">ṯaliṯ</w>
                      <w xml:id="wid_00259" join="right">walād</w>
                      <pc type="ws" xml:id="id_pc_704">.</pc>
                   </quote>
@@ -1393,7 +1393,7 @@
                      <w xml:id="wid_00819">tišrab</w>
                      <w ana="semlib:tea" xml:id="wid_00820">čāy</w>
                      <w xml:id="wid_00821">alli</w>
-                     <w ana="semlib:coffee vt_phon_CA_q" xml:id="wid_00822" join="right">ghawa</w>
+                     <w ana="semlib:coffee fvlib:phon.CA_q" xml:id="wid_00822" join="right">ghawa</w>
                      <pc type="ws" xml:id="id_pc_2226">?</pc>
                      <w xml:id="wid_00823">–</w>
                      <phr ana="semlib:please">
@@ -1726,7 +1726,7 @@
                   </quote>
                </cit>
             </cit>
-            <cit ana="semlib:possibility" type="featureSample">
+            <cit ana="fvlib:subc.posbl" type="featureSample">
                <lbl xml:space="preserve">possibility</lbl>
                <quote xml:lang="en">Can you come tomorrow?</quote>
                <cit type="translation">

--- a/vocabs/fLib.rdf
+++ b/vocabs/fLib.rdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-   <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   <ConceptScheme xmlns="http://www.w3.org/2004/02/skos/core#"
                        rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features">
       <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en">This document contains the feature value library used in all VICAV dictionaries.</dc:description>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Charly Mörth</dc:creator>
@@ -9,16 +9,16 @@
       <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en">VICAV feature-value library</dc:title>
       <rdfs:label xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xml:lang="en">VICAV feature-value library</rdfs:label>
       <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Austrian Centre for Digital Humanities</dc:publisher>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Part of Speech"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Derived Verb Class"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Tense"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Mood"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Number"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Gender"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Person"/>
-      <skos:hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other Subcategories"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Part of Speech"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Derived Verb Class"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Tense"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Mood"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Number"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Gender"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Person"/>
+      <hasTopConcept rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other Subcategories"/>
       <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">en</dc:language>
-   </skos:ConceptScheme>
+   </ConceptScheme>
    <Concept xmlns="http://www.w3.org/2004/02/skos/core#"
             rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Part_of_Speech">
       <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
@@ -348,6 +348,34 @@
       <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Person"/>
       <prefLabel xml:lang="en">3rd</prefLabel>
    </Concept>
+
+   <Concept xmlns="http://www.w3.org/2004/02/skos/core#"
+      rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_phon">
+      <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
+      <topConceptOf rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
+      <prefLabel xml:lang="en">Phonological</prefLabel>
+      <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_phon.CA_q"/>
+      <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_phon.CA_th"/>
+   </Concept>
+   
+   <Concept xmlns="http://www.w3.org/2004/02/skos/core#"
+      rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.CA_q">
+      <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
+      <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_phon"/>
+      <prefLabel xml:lang="en">ClassicalArabicQ</prefLabel>
+      <definition>Reflexes of Classical Arabic Q phoneme</definition>
+   </Concept>
+   
+   <Concept xmlns="http://www.w3.org/2004/02/skos/core#"
+      rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.CA_th">
+      <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
+      <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_phon"/>
+      <prefLabel xml:lang="en">ClassicalArabicTh</prefLabel>
+      <definition>Reflexes of Classical Arabic Th phoneme</definition>
+   </Concept>
+   
+   
+
    <Concept xmlns="http://www.w3.org/2004/02/skos/core#"
             rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other_Subcategories">
       <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
@@ -363,6 +391,9 @@
       <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.prox"/>
       <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.dist"/>
       <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.vicis"/>
+      <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.genexp"/>
+      <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.posbl"/>
+      <narrower rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.exist"/>
    </Concept>
    <Concept xmlns="http://www.w3.org/2004/02/skos/core#"
             rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.artPl">
@@ -423,5 +454,27 @@
       <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
       <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other_Subcategories"/>
       <prefLabel xml:lang="en">nomenVicis</prefLabel>
+   </Concept>
+   
+   
+   <Concept xmlns="http://www.w3.org/2004/02/skos/core#" rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.exist">
+      <prefLabel xml:lang="en">existential</prefLabel>
+      <altLabel xml:lang="en">existential (there is, there are)</altLabel>
+      <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other_Subcategories"/>
+      <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
+   </Concept>
+   
+   
+   <Concept xmlns="http://www.w3.org/2004/02/skos/core#" rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.genexp">
+      <prefLabel xml:lang="en">genitiveExplicative</prefLabel>
+      <prefLabel xml:lang="en">Genitive explicative</prefLabel>
+      <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other_Subcategories"/>
+      <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
+   </Concept>
+   
+   <Concept xmlns="http://www.w3.org/2004/02/skos/core#" rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_subc.posbl">
+      <prefLabel xml:lang="en">possibility</prefLabel>
+      <broader rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features#vt_Other_Subcategories"/>
+      <inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/features"/>
    </Concept>
 </rdf:RDF>

--- a/vocabs/fLib.xml
+++ b/vocabs/fLib.xml
@@ -240,6 +240,11 @@
                <f xml:id="pers.2" name="secondPerson"><symbol value="2nd"/></f>
                <f xml:id="pers.3" name="thirdPerson"><symbol value="3rd"/></f>
            </fLib>
+             
+             <fLib n="Phonological">   
+                 <f xml:id="phon.CA_q" name="classicalArabicQ"><symbol value="classicalArabicQ"/></f>
+                 <f xml:id="phon.CA_th" name="classicalArabicTh"><symbol value="classicalArabicTh"/></f>
+             </fLib>
             
             <fLib n="Other Subcategories">
                <!-- Discuss the term --> 
@@ -252,7 +257,10 @@
                <f xml:id="subc.unitNoun" name="unitNoun"><symbol value="unitNoun"/></f>               
                <f xml:id="subc.prox" name="proximal"><symbol value="proximal"/></f>               
                <f xml:id="subc.dist" name="distal"><symbol value="distal"/></f>               
-               <f xml:id="subc.vicis" name="nomenVicis"><symbol value="nomenVicis"/></f>               
+               <f xml:id="subc.vicis" name="nomenVicis"><symbol value="nomenVicis"/></f>  
+               <f xml:id="subc.posbl" name="possibility"><symbol value="possibility"/></f>  
+               <f xml:id="subc.exist" name="existential"><symbol value="existential"/></f> 
+               <f xml:id="subc.genexp" name="genitiveExplicative"><symbol value="genitiveExplicative"/></f> 
             </fLib>                          
          </div>
       </body>

--- a/vocabs/vt_lex.rdf
+++ b/vocabs/vt_lex.rdf
@@ -478,24 +478,4 @@
          <skos:inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex"/>
       </skos:Concept>
    
-   
-      <skos:Concept rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#existential">
-         <skos:prefLabel xml:lang="en">existential</skos:prefLabel>
-       
-         <skos:inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex"/>
-      </skos:Concept>
-   
-   
-      <skos:Concept rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#gen_explicative">
-         <skos:prefLabel xml:lang="en">gen explicative</skos:prefLabel>
-       
-         <skos:inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex"/>
-      </skos:Concept>
-   
-   
-      <skos:Concept rdf:about="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex#possibility">
-         <skos:prefLabel xml:lang="en">possibility</skos:prefLabel>
-       
-         <skos:inScheme rdf:resource="https://vocabs.acdh.oeaw.ac.at/vicav/vt_lex"/>
-      </skos:Concept>
 </rdf:RDF>


### PR DESCRIPTION
So, there were a few more explore entries that ceased work because the old vt_tags still used hashmark notation while I removed that code. Also the automatic relacement didn't work for some entries tp the newer semplib notation apparently, so fixed those as well.